### PR TITLE
feat(local): make gitops targetRevision configurable

### DIFF
--- a/cluster/local/main.tf
+++ b/cluster/local/main.tf
@@ -55,7 +55,7 @@ applications:
 
     source:
       repoURL: https://github.com/IntegratedDynamic/gitops.git
-      targetRevision: main
+      targetRevision: ${var.gitops_revision}
       path: bootstrap
 
     destination:

--- a/cluster/local/variables.tf
+++ b/cluster/local/variables.tf
@@ -5,3 +5,8 @@ variable "infisical_client_id" {
 variable "infisical_client_secret" {
     type = string
 }
+
+variable "gitops_revision" {
+  type    = string
+  default = "main"
+}


### PR DESCRIPTION
## Summary

- Add `gitops_revision` variable to `cluster/local/` (default: `main`)
- Wire it into the ArgoCD apps `targetRevision` in the bootstrap Helm release

## Usage

In `cluster/local/nico.auto.tfvars`:
```hcl
gitops_revision = "my-branch"
```

## Test plan

- [ ] `mise run dev` with no `gitops_revision` set targets `main` as before
- [ ] Setting `gitops_revision = "my-branch"` in `nico.auto.tfvars` makes ArgoCD track that branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)