### PR TITLE
feat: propagate gitops_revision through the app-of-apps tree

### DIFF
--- a/cluster/local/main.tf
+++ b/cluster/local/main.tf
@@ -57,6 +57,12 @@ applications:
       repoURL: https://github.com/IntegratedDynamic/gitops.git
       targetRevision: ${var.gitops_revision}
       path: bootstrap
+      helm:
+        parameters:
+          - name: env
+            value: local
+          - name: revision
+            value: ${var.gitops_revision}
 
     destination:
       server: https://kubernetes.default.svc


### PR DESCRIPTION
## What

Passes `env` + `revision` Helm parameters to the `bootstrap` ArgoCD Application, so the `gitops_revision` variable propagates from this provisioner all the way down the gitops app-of-apps tree instead of stopping at the top-level app.

## Why

Previously `gitops_revision` only reached the `bootstrap` Application; every child app (`local`, `platform`, `demo`) hard-pinned `main` in the gitops repo. That meant a feature branch could never be validated end-to-end on the local cluster — the `platform` app kept reading `main`.

With this change, setting `gitops_revision` to a feature branch deploys the **whole** tree from that branch (defaulting to `main` when unset). Exactly what we want for a local/dev cluster.

## Pairs with

gitops repo PR: IntegratedDynamic/gitops#2 (turns `bootstrap/` and `clusters/local/` into Helm charts that consume these params).

> ⚠️ Merge the gitops PR first (or together) — this change expects the `bootstrap` path to be a Helm chart accepting `env`/`revision`.

## Validation

Full `mise run reset && mise run dev` from a feature branch: all 6 ArgoCD apps `Synced/Healthy`, monitoring stack up, Grafana reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)