### PR TITLE
feat(scaleway): consolidate cluster + ArgoCD bootstrap

### DIFF
--- a/cluster/scaleway/.terraform.lock.hcl
+++ b/cluster/scaleway/.terraform.lock.hcl
@@ -1,6 +1,46 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.9.0"
   constraints = "~> 2.0"
@@ -23,7 +63,8 @@ provider "registry.terraform.io/hashicorp/local" {
 }
 
 provider "registry.terraform.io/hashicorp/null" {
-  version = "3.3.0"
+  version     = "3.3.0"
+  constraints = "~> 3.0"
   hashes = [
     "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
     "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
@@ -39,6 +80,29 @@ provider "registry.terraform.io/hashicorp/null" {
     "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
     "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
     "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}
+
+provider "registry.terraform.io/infisical/infisical" {
+  version     = "0.16.26"
+  constraints = "~> 0.16"
+  hashes = [
+    "h1:IkYJCDS/T+DOphpxxD7DRR0DLVerV4qAQHti85SVIVQ=",
+    "zh:013b47edce338eb6ed75112ebb2753a61e016abdeb0553865ed410c3f31c6efb",
+    "zh:14ced8e88b66c035e808ac5276dc7cdd9d761d91b54ad69de6262204c2c674a5",
+    "zh:1f6463f27bbfd083d91ccbbba8699e378b7c3fdb5c93f0e88c923f39889f940a",
+    "zh:22aa61e3336143cdc21657976bb2ac5ec9dcd2a1ba5fab5b2d9b86f038bffceb",
+    "zh:4369440e1e8e8cabc0c6fc40371c3cd82641327c4c0e08f9f2bbf82ef7fe964a",
+    "zh:43a61b60fa523dffabdf37dc03e812843ce9595eca86274370ac83645d392d33",
+    "zh:494fbaab19beeca24f4bca073191f8b3ba4bfcb854ebfe96b108759b803c982a",
+    "zh:6c1f8d4322bf88d099ec187c2b42f305bb8303202bc5f9536815eee656a811eb",
+    "zh:7a479efa33ed935cca48614af7911ecff097338eb1e090d6f0c9e548fa4ba44b",
+    "zh:7e31b46281ff25d2d50d79e458d50e5b591aff6bcde7d12667f89d977c3f7dda",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:8eaac63871bc4b3a6dd8824dbb75d8f1bea7b2569a7f1145229f9a225eb14b55",
+    "zh:b3385a2fe0ca595b1846df9010892789d0bcfe92076e815ac33afa3c56d1f177",
+    "zh:bc7bfa6c842a6eb69458693f99cdc47504f2c6290dfb295208265709ca653318",
+    "zh:da6a64f6f340cbcd86cbbcbd1b7bf61be4c2f5ed9833899bd3d4a72076e4eb85",
   ]
 }
 

--- a/cluster/scaleway/main.tf
+++ b/cluster/scaleway/main.tf
@@ -51,3 +51,121 @@ resource "local_file" "kubeconfig" {
   filename        = pathexpand("~/.kube/scaleway-homelab.yaml")
   file_permission = "0600"
 }
+
+# Scaleway regional IDs are "<region>/<uuid>"; the scw CLI wants the bare UUID,
+# and the generated kubeconfig context is named "<cluster-name>-<uuid>".
+locals {
+  cluster_uuid = split("/", scaleway_k8s_cluster.homelab.id)[1]
+}
+
+# Optional local DevX: merge this cluster into ~/.kube/config via the Scaleway
+# CLI (instead of juggling the standalone file above). Opt-in via
+# install_kubeconfig = true in your *.auto.tfvars. `scw k8s kubeconfig install`
+# has no rename flag, so we rename the context cleanly with kubectl afterwards.
+resource "null_resource" "install_kubeconfig" {
+  count = var.install_kubeconfig ? 1 : 0
+
+  triggers = {
+    cluster_id   = scaleway_k8s_cluster.homelab.id
+    context_name = var.kubeconfig_context_name
+  }
+
+  depends_on = [null_resource.kubeconfig]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      scw k8s kubeconfig install ${local.cluster_uuid}
+      # Override any pre-existing context with the target name, then rename.
+      kubectl config delete-context "${var.kubeconfig_context_name}" 2>/dev/null || true
+      kubectl config rename-context "${scaleway_k8s_cluster.homelab.name}-${local.cluster_uuid}" "${var.kubeconfig_context_name}"
+    EOT
+  }
+}
+
+# ── ArgoCD bootstrap (toggle with var.bootstrap_argocd) ─────────────────────
+
+data "infisical_secrets" "this" {
+  count        = var.bootstrap_argocd ? 1 : 0
+  env_slug     = "staging"
+  workspace_id = "7ecb6ed4-058a-46cd-ac9f-7e792469cf0f" // project ID
+  folder_path  = "/"
+}
+
+resource "helm_release" "argocd" {
+  count            = var.bootstrap_argocd ? 1 : 0
+  name             = "argocd"
+  namespace        = "argocd"
+  create_namespace = true
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argo-cd"
+  version    = "9.4.17"
+
+  # Fail fast (under the 5m default) if ArgoCD doesn't come up. Transient blips
+  # (e.g. quay.io 502s) are absorbed by retrying the apply (see mise scaleway-up).
+  timeout = 240
+
+  depends_on = [local_file.kubeconfig]
+
+  set_sensitive {
+    name = "configs.secret.argocdServerAdminPassword"
+    # ArgoCD expects a bcrypt() hash here. bcrypt() would regenerate on every
+    # run, so we store the hash directly in Infisical to avoid spurious diffs.
+    value = data.infisical_secrets.this[0].secrets["ArgoCD_admin_encrypted"].value
+  }
+
+  values = [<<EOF
+configs:
+  params:
+    server.insecure: true
+
+controller:
+  replicas: 1
+
+repoServer:
+  replicas: 1
+EOF
+  ]
+}
+
+resource "helm_release" "argocd_apps" {
+  count     = var.bootstrap_argocd ? 1 : 0
+  name      = "argocd-apps"
+  namespace = "argocd"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.4"
+
+  depends_on = [helm_release.argocd]
+
+  values = [<<EOF
+applications:
+  bootstrap:
+    namespace: argocd
+    project: default
+
+    source:
+      repoURL: https://github.com/IntegratedDynamic/gitops.git
+      targetRevision: ${var.gitops_revision}
+      path: bootstrap
+      helm:
+        parameters:
+          - name: env
+            value: scaleway
+          - name: revision
+            value: ${var.gitops_revision}
+
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: argocd
+
+    syncPolicy:
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+EOF
+  ]
+}

--- a/cluster/scaleway/variables.tf
+++ b/cluster/scaleway/variables.tf
@@ -1,3 +1,16 @@
+# Required only when bootstrap_argocd = true (to read the ArgoCD admin hash).
+# Default empty so a cluster-only provision (bootstrap_argocd = false) needs no creds.
+variable "infisical_client_id" {
+  type    = string
+  default = ""
+}
+
+variable "infisical_client_secret" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
 variable "k8s_version" {
   type    = string
   default = "1.32.3"
@@ -6,4 +19,27 @@ variable "k8s_version" {
 variable "node_count" {
   type    = number
   default = 1
+}
+
+variable "bootstrap_argocd" {
+  description = "Install ArgoCD + the bootstrap Application on the cluster. Set false to provision the cluster alone (e.g. the very first apply, before the kubeconfig exists)."
+  type        = bool
+  default     = true
+}
+
+variable "install_kubeconfig" {
+  description = "Merge this cluster into ~/.kube/config via `scw k8s kubeconfig install` for local DevX. Opt-in (set true in your *.auto.tfvars)."
+  type        = bool
+  default     = false
+}
+
+variable "kubeconfig_context_name" {
+  description = "Clean context name to rename the installed kubeconfig entry to (scw names it <cluster>-<id> and has no rename flag)."
+  type        = string
+  default     = "scaleway-homelab"
+}
+
+variable "gitops_revision" {
+  type    = string
+  default = "main"
 }

--- a/cluster/scaleway/version.tf
+++ b/cluster/scaleway/version.tf
@@ -12,7 +12,46 @@ terraform {
       source  = "hashicorp/null"
       version = "~> 3.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    infisical = {
+      source  = "infisical/infisical"
+      version = "~> 0.16"
+    }
   }
 }
 
 provider "scaleway" {}
+
+provider "infisical" {
+  auth = {
+    universal = {
+      client_id     = var.infisical_client_id
+      client_secret = var.infisical_client_secret
+    }
+  }
+}
+
+# kubernetes/helm talk to the cluster directly via its Scaleway-issued
+# kubeconfig attributes (no local-file dependency). On a from-scratch apply,
+# run once with -var bootstrap_argocd=false: the cluster doesn't exist yet so
+# these values are unknown, and gating ArgoCD off avoids exercising them.
+provider "kubernetes" {
+  host                   = scaleway_k8s_cluster.homelab.kubeconfig[0].host
+  token                  = scaleway_k8s_cluster.homelab.kubeconfig[0].token
+  cluster_ca_certificate = base64decode(scaleway_k8s_cluster.homelab.kubeconfig[0].cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = scaleway_k8s_cluster.homelab.kubeconfig[0].host
+    token                  = scaleway_k8s_cluster.homelab.kubeconfig[0].token
+    cluster_ca_certificate = base64decode(scaleway_k8s_cluster.homelab.kubeconfig[0].cluster_ca_certificate)
+  }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -48,28 +48,30 @@ run = "minikube delete"
 # ── Scaleway (homelab) ──────────────────────────────────────────────────────
 
 [tasks.scaleway-provision]
-description = "Provision Scaleway Kapsule cluster"
-dir = "cluster/scaleway/kapsule"
-run = "terraform init && terraform apply -auto-approve"
-
-[tasks.scaleway-apps]
-description = "Bootstrap ArgoCD on Scaleway cluster"
-dir = "cluster/scaleway/apps"
-run = "terraform init && terraform apply -auto-approve"
+description = "Provision the Scaleway cluster only (no ArgoCD). Use for the first from-scratch apply."
+dir = "cluster/scaleway"
+run = "terraform init && terraform apply -auto-approve -var bootstrap_argocd=false"
 
 [tasks.scaleway-up]
-description = "Provision Scaleway cluster + deploy ArgoCD"
+description = "Provision the Scaleway cluster + bootstrap ArgoCD"
+dir = "cluster/scaleway"
 run = """
-mise run scaleway-provision
-mise run scaleway-apps
+terraform init
+n=0
+until terraform apply -auto-approve; do
+  n=$((n + 1))
+  if [ "$n" -ge 3 ]; then echo "terraform apply failed after $n attempts"; exit 1; fi
+  echo "apply attempt $n failed (likely a transient registry/API blip); retrying in 15s..."
+  sleep 15
+done
 """
 
 [tasks.scaleway-pause]
 description = "Scale Scaleway node pool to 0 (free tier)"
-dir = "cluster/scaleway/kapsule"
+dir = "cluster/scaleway"
 run = "terraform apply -auto-approve -var='node_count=0'"
 
 [tasks.scaleway-resume]
 description = "Scale Scaleway node pool back to 1"
-dir = "cluster/scaleway/kapsule"
+dir = "cluster/scaleway"
 run = "terraform apply -auto-approve -var='node_count=1'"


### PR DESCRIPTION
## What

Builds on #12 (the pure move). Adds the ArgoCD bootstrap to the consolidated `cluster/scaleway` module — shown as clean **in-place** edits since the rename already happened in #12.

## Changes

- **`var.bootstrap_argocd`** (default true) gates ArgoCD + the bootstrap Application via `count`; `false` provisions the cluster alone.
- **kubernetes/helm providers** configured from the Scaleway cluster's kubeconfig attributes directly (no local-file dependency).
- **ArgoCD admin password via Infisical** (`env_slug=staging`), set with `set_sensitive`; data source + creds gated/optional under `bootstrap_argocd`.
- Bootstrap Application passes **`env=scaleway` + `revision`** so the gitops tree deploys from the chosen ref.
- **Fail fast + retry**: `helm_release.argocd` timeout 240s (keeps `wait`); transient registry blips absorbed by retrying `terraform apply` up to 3× in `mise run scaleway-up`.
- **Optional `scw k8s kubeconfig install`** for local DevX (`install_kubeconfig`), renaming the context cleanly (`kubeconfig_context_name`, default `scaleway-homelab`).
- **mise tasks** repointed at the consolidated module.

## Pairs with

gitops PR IntegratedDynamic/gitops#4 (the `scaleway` env).

## Merge order

Merge #12 first, then this (it'll retarget to `main` automatically).

## Validation

Applied end-to-end on the real Kapsule cluster (tracking gitops `feat/scaleway-env`): 5 ArgoCD apps `Synced/Healthy`, monitoring pods up, **Grafana verified** via port-forward (`admin`/`admin`, `/api/health` ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)