### PR TITLE
ci: run workflow lint on pull_request only

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,9 +1,6 @@
 name: Lint GitHub Actions Workflows
 
 on:
-  push:
-    paths:
-      - '.github/workflows/**'
   pull_request:
     paths:
       - '.github/workflows/**'


### PR DESCRIPTION
## Context

`lint-workflows.yml` triggered on both `push` and `pull_request` for `.github/workflows/**`. Since everything lands through a PR, the `push` run added no coverage — it only duplicated jobs and doubled exposure to transient failures (e.g. on #17 the `push`-triggered `actionlint` hit a GitHub API `500` while resolving the latest actionlint release, while the `pull_request` run passed).

## Changes

- Drop the `push` trigger from `lint-workflows.yml`; keep `pull_request` only. Mirrors the `terraform-lock.yml` workflow.

## How to verify

- `actionlint .github/workflows/*.yml` passes locally.
- On this PR, `actionlint` + `zizmor` run once (no duplicate `push` run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)