### PR TITLE
feat: provision terraform-ci IAM identity for cluster/scaleway CI

### DIFF
--- a/.github/workflows/scaleway-auth-check.yml
+++ b/.github/workflows/scaleway-auth-check.yml
@@ -1,16 +1,19 @@
 name: Scaleway Auth Check
 
-# Validates the github-ci/ Scaleway IAM key end to end: authenticate with the
-# scoped API key from GitHub secrets and list the fr-par Object Storage buckets.
-# This is a smoke test, not part of any pipeline yet.
+# Validates the Scaleway IAM keys end to end: authenticate with each scoped API
+# key from GitHub secrets and list the fr-par Object Storage buckets.
+#   - list-buckets                 → github-ci/ read-only key (SCW_*)
+#   - list-state-bucket-terraform-ci → terraform-ci/ R/W key (TF_SCW_*)
+# These are smoke tests, not part of any pipeline yet.
 #
-# Runs on PRs that touch the CI identity so it can be validated before merge.
+# Runs on PRs that touch a CI identity so it can be validated before merge.
 
 on:
   pull_request:
     paths:
       - '.github/workflows/scaleway-auth-check.yml'
       - 'github-ci/**'
+      - 'terraform-ci/**'
 
 permissions:
   contents: read
@@ -41,6 +44,39 @@ jobs:
           version: v2.41.0
           access-key: ${{ secrets.SCW_ACCESS_KEY }}
           secret-key: ${{ secrets.SCW_SECRET_KEY }}
+          # Public identifiers (not credentials) the scw CLI wants even for a
+          # project-scoped key. Repo variables, not secrets.
+          default-organization-id: ${{ vars.SCW_DEFAULT_ORGANIZATION_ID }}
+          default-project-id: ${{ vars.SCW_DEFAULT_PROJECT_ID }}
+          args: object bucket list region=fr-par
+
+  # Validates the terraform-ci/ R/W key: authenticate with TF_SCW_* and list the
+  # fr-par Object Storage buckets (the Terraform state backend lives there), which
+  # exercises the ObjectStorageReadWrite grant before the Terraform CI workflows
+  # (#29) ever consume the key.
+  list-state-bucket-terraform-ci:
+    runs-on: ubuntu-latest
+    # Same dedicated environment as above so secret usage stays scoped.
+    environment: scaleway
+    steps:
+      # Fail fast and clearly if the secrets aren't set, instead of letting the
+      # CLI emit a confusing auth error (or worse, appear to pass).
+      - name: Assert credentials are present
+        env:
+          TF_SCW_ACCESS_KEY: ${{ secrets.TF_SCW_ACCESS_KEY }}
+          TF_SCW_SECRET_KEY: ${{ secrets.TF_SCW_SECRET_KEY }}
+        run: |
+          if [ -z "$TF_SCW_ACCESS_KEY" ] || [ -z "$TF_SCW_SECRET_KEY" ]; then
+            echo "::error::TF_SCW_ACCESS_KEY and/or TF_SCW_SECRET_KEY are not set. Run 'gh secret set' (see terraform-ci/README.md)."
+            exit 1
+          fi
+
+      - name: List fr-par Object Storage buckets (Terraform state backend)
+        uses: scaleway/action-scw@2e34a1eb35cf3cac627f24643a101fea269cbd83 # v0.0.3
+        with:
+          version: v2.41.0
+          access-key: ${{ secrets.TF_SCW_ACCESS_KEY }}
+          secret-key: ${{ secrets.TF_SCW_SECRET_KEY }}
           # Public identifiers (not credentials) the scw CLI wants even for a
           # project-scoped key. Repo variables, not secrets.
           default-organization-id: ${{ vars.SCW_DEFAULT_ORGANIZATION_ID }}

--- a/.github/workflows/scaleway-auth-check.yml
+++ b/.github/workflows/scaleway-auth-check.yml
@@ -2,8 +2,9 @@ name: Scaleway Auth Check
 
 # Validates the Scaleway IAM keys end to end: authenticate with each scoped API
 # key from GitHub secrets and list the fr-par Object Storage buckets.
-#   - list-buckets                 → github-ci/ read-only key (SCW_*)
-#   - list-state-bucket-terraform-ci → terraform-ci/ R/W key (TF_SCW_*)
+#   - list-buckets                   → github-ci/ read-only key (SCW_*), via scw CLI
+#   - list-state-bucket-terraform-ci → terraform-ci/ R/W key (TF_SCW_*), via aws CLI
+#     (the Terraform state backend is now AWS S3, Scaleway-hosted)
 # These are smoke tests, not part of any pipeline yet.
 #
 # Runs on PRs that touch a CI identity so it can be validated before merge.
@@ -50,35 +51,21 @@ jobs:
           default-project-id: ${{ vars.SCW_DEFAULT_PROJECT_ID }}
           args: object bucket list region=fr-par
 
-  # Validates the terraform-ci/ R/W key: authenticate with TF_SCW_* and list the
-  # fr-par Object Storage buckets (the Terraform state backend lives there), which
-  # exercises the ObjectStorageReadWrite grant before the Terraform CI workflows
-  # (#29) ever consume the key.
+  # Validates the terraform-ci/ R/W key against the AWS S3 backend. The Terraform
+  # state migrated from the Scaleway CLI to AWS S3 (Scaleway-hosted, S3-compatible),
+  # so we exercise the key the same way Terraform does: an `aws s3 ls` against the
+  # S3 endpoint. This confirms the ObjectStorageReadWrite grant works before the
+  # Terraform CI workflows (#29) ever consume the key. AWS CLI is pre-installed on
+  # ubuntu-latest, so no setup step is needed.
   list-state-bucket-terraform-ci:
     runs-on: ubuntu-latest
     # Same dedicated environment as above so secret usage stays scoped.
     environment: scaleway
     steps:
-      # Fail fast and clearly if the secrets aren't set, instead of letting the
-      # CLI emit a confusing auth error (or worse, appear to pass).
-      - name: Assert credentials are present
+      - name: List S3 buckets (Terraform state backend)
         env:
-          TF_SCW_ACCESS_KEY: ${{ secrets.TF_SCW_ACCESS_KEY }}
-          TF_SCW_SECRET_KEY: ${{ secrets.TF_SCW_SECRET_KEY }}
-        run: |
-          if [ -z "$TF_SCW_ACCESS_KEY" ] || [ -z "$TF_SCW_SECRET_KEY" ]; then
-            echo "::error::TF_SCW_ACCESS_KEY and/or TF_SCW_SECRET_KEY are not set. Run 'gh secret set' (see terraform-ci/README.md)."
-            exit 1
-          fi
-
-      - name: List fr-par Object Storage buckets (Terraform state backend)
-        uses: scaleway/action-scw@2e34a1eb35cf3cac627f24643a101fea269cbd83 # v0.0.3
-        with:
-          version: v2.41.0
-          access-key: ${{ secrets.TF_SCW_ACCESS_KEY }}
-          secret-key: ${{ secrets.TF_SCW_SECRET_KEY }}
-          # Public identifiers (not credentials) the scw CLI wants even for a
-          # project-scoped key. Repo variables, not secrets.
-          default-organization-id: ${{ vars.SCW_DEFAULT_ORGANIZATION_ID }}
-          default-project-id: ${{ vars.SCW_DEFAULT_PROJECT_ID }}
-          args: object bucket list region=fr-par
+          AWS_ACCESS_KEY_ID: ${{ secrets.TF_SCW_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_SCW_SECRET_KEY }}
+          AWS_DEFAULT_REGION: eu-west-3
+          AWS_ENDPOINT_URL_S3: https://s3.fr-par.scw.cloud
+        run: aws s3 ls

--- a/.github/workflows/terraform-lock.yml
+++ b/.github/workflows/terraform-lock.yml
@@ -27,6 +27,7 @@ jobs:
           - cluster/local
           - cluster/scaleway
           - github-ci
+          - terraform-ci
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/mise.toml
+++ b/mise.toml
@@ -103,6 +103,23 @@ description = "terraform apply on the github-ci root (provisions the Scaleway CI
 dir = "github-ci"
 run = "terraform apply"
 
+# ── Terraform CI identity (terraform-ci/) ────────────────────────────────────
+
+[tasks.terraform-ci-init]
+description = "terraform init on the terraform-ci root"
+dir = "terraform-ci"
+run = "terraform init"
+
+[tasks.terraform-ci-plan]
+description = "terraform plan on the terraform-ci root"
+dir = "terraform-ci"
+run = "terraform init && terraform plan"
+
+[tasks.terraform-ci-apply]
+description = "terraform apply on the terraform-ci root (provisions the Scaleway Terraform CI IAM key)"
+dir = "terraform-ci"
+run = "terraform apply"
+
 # ── Provider locks ───────────────────────────────────────────────────────────
 
 [tasks.lock]
@@ -112,4 +129,5 @@ terraform -chdir=terraform-state-bucket providers lock -platform=darwin_arm64 -p
 terraform -chdir=cluster/local          providers lock -platform=darwin_arm64 -platform=linux_amd64
 terraform -chdir=cluster/scaleway       providers lock -platform=darwin_arm64 -platform=linux_amd64
 terraform -chdir=github-ci              providers lock -platform=darwin_arm64 -platform=linux_amd64
+terraform -chdir=terraform-ci           providers lock -platform=darwin_arm64 -platform=linux_amd64
 """

--- a/terraform-ci/.terraform.lock.hcl
+++ b/terraform-ci/.terraform.lock.hcl
@@ -1,0 +1,70 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = "~> 0.12"
+  hashes = [
+    "h1:/hlxsUpuN/lvPTNL9+NyVGsOyRsK5NsxwFMsj5CdOp4=",
+    "h1:4EThC3ocCFiFPMZQSUvSGSxoJqBcGWxMcFYmL67uS7Y=",
+    "zh:12abfd6b800e4d7fa6db7310dec8ffd440b31993861ef188c7ed5260b3073937",
+    "zh:23005521e800bb19e1597bf755c5f70d675d30b685d4255001ed5fa47d9df3f1",
+    "zh:2fea249b582ae97cd1cc10385187ea50993bb47c28cc5df0305e57ceaabf0a10",
+    "zh:322018d3b987b7aad08697178029a2bb667bed699e88328f0c89c52a2fd41341",
+    "zh:32a08e98fce2d273cb9b2c89d6c54727cc9f0a32e15bfd896be4e02cc6b48f95",
+    "zh:3db89aabd0e619616bd4b0f8b373a7586dfe60feffcea12a84a0bdbc445714b3",
+    "zh:7488f56c81d742dc020f29063626c8f07ca188aa97be61e7307e8d62397020a2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7cb4067f2e7559b13f7562ef722f948950901eb37834873e98360ab28f66e9d7",
+    "zh:9d552c8345f61e1b7db8e725144981345f18ac1014d58d6f5ddf0928a195fffb",
+    "zh:a8e69fb6b97fc9d86fb19a9f4d42abe33c4a68e700b15387ce2e17d2b9934bed",
+    "zh:aeeb900eb8dd0f790c60ea5c0e0c8d42bd6e4a54f391681d4decca15b544394b",
+    "zh:c239c619101a8c95e1f14061eb973c57a8d15fa0e68878ced5bbd76858ee5b79",
+  ]
+}
+
+provider "registry.terraform.io/infisical/infisical" {
+  version     = "0.16.28"
+  constraints = "~> 0.16"
+  hashes = [
+    "h1:3u5WxYFLl+DUSqoma4DEY/DYbN7fMt6yTDcrkpFQz5Q=",
+    "h1:BvcG6jgReLptymYOXetIEpaZBLA2rsbexEl7THzENM0=",
+    "zh:09d25451a3ebbb1e9ba5a73f29f6c9dfd2f890c3966ec66af401969164b42a67",
+    "zh:2e1eac9f42920336694baaa83e1e0ae252d4fded21d3c4ce874831c8ca9575b4",
+    "zh:306b370bdfb18ffb0d819c613fb2bc3377037a9be47a70ecdd6cc2e83bdeff14",
+    "zh:63d6291c6a81fe9d1469ff86d4dc2b6e8fbf93e255d0f3d58f98cfdc6817fc98",
+    "zh:66f01a8234b079cb3e9e80eefa2ee2d107191632d03db84fa5da42ad8e925261",
+    "zh:75794f043a2320a67706fe545f488d4cbaaccae844622b2a80967198f39bf226",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:a66be07dd80c836b7bd44cc1818b35156665b50011209711ce264e4320c6ef9d",
+    "zh:ae895218e7616f439cc03ce98d1d9179741df89abb72520d70773fd427adf320",
+    "zh:bbb50efbfb6d1dd29013329fd38ab72e5b7b4694b840aae84e550f1991cee1a1",
+    "zh:c25cfe7ecf55201bd2433dc5d4dfe3bf608c75f3c22a3ec3f146636fef75a9dd",
+    "zh:d54fc418ff11ffd11fce7b02c77735686ee4efcb2222c9f62dd85d5a275cda4b",
+    "zh:e38e93b6f72204f37475b692c3c9878b62ebdd5ee2eabac90b9368f6651c3f88",
+    "zh:ed9a4625835728b0d6d8fa82be0cf6d71224654666223e0e74f49471ba12e90e",
+    "zh:f85e74fae43fb35182c99b2a1cc57cf40aa831218d359fe48f66e66b89ec5f9b",
+  ]
+}
+
+provider "registry.terraform.io/scaleway/scaleway" {
+  version     = "2.76.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:3RImo3Jf88dXcIqmBRuO/A85jAxrAQsvYa4zhVqW1tI=",
+    "h1:ktRogBsJlCf3JTOTYPm9hKaPUzaps0aLwxsNfP155ns=",
+    "zh:13b6790dca2c91c7478d6e9cd03d84713e0b0ec001c9923d3c93bd12a1f4152f",
+    "zh:219582ef77ec6f27d2928684b95603b5a921001631f9eec68c14819fdbc1efea",
+    "zh:26bc09c7aadc49fe83a9d6af9c1d0951f93de129f90d04e5e65e1d82c8ac1914",
+    "zh:4015a970be3669ee009344afb269a09eaf9fe1363a12a10d3311326ba769463a",
+    "zh:4c1c5997ef4182e49e46ff6563581a90b5cfa30f0ec8d7d919b3dc0603ed3043",
+    "zh:58d91e08a8fe38ddda2c03013d1ba77ff4e21a91fef0a425575b5af7bf7f4ebc",
+    "zh:644a61f963483c8eba7f8427650c4956e1d8c59710a11bb2691ad8996ee14a9c",
+    "zh:6745d5d80006c375b104a005cfc007f90e2cb547cf9e96c886d453be3307a399",
+    "zh:8dcac392ca182af40b823c6721833de1325c279b1e5bdcddf1a1cf2789f3558a",
+    "zh:9eb284d3e9a14d4d64e2a7a865be45ec0eee32ec16c51bcc1722c0449bfb9fab",
+    "zh:a4eb4973cc1d9ac4911733d62f5b0e53fbc7b90112efa312918c0320966e276e",
+    "zh:ce58ae8014b2981bbc875bc7ad4cdeb93957370bfa4308eeb193155ee988fbec",
+    "zh:d3f0f3bec0a6f4759948749cdb0eb64e4415507a82c79659f1ede894f96f4976",
+  ]
+}

--- a/terraform-ci/README.md
+++ b/terraform-ci/README.md
@@ -1,0 +1,173 @@
+# terraform-ci
+
+A standalone Terraform root that provisions the **Scaleway identity the Terraform
+CI/CD pipeline uses to apply `cluster/scaleway`**. Its first consumers are the
+workflows added in #29 (`terraform-apply.yml`, `terraform-destroy-manual.yml`,
+`terraform-destroy-scheduled.yml`), which run `terraform apply`/`destroy` against
+the Scaleway Kapsule cluster, node pool, VPC and the S3 state backend.
+
+This is **not** under `cluster/` — it provisions no cluster. It's a CI-platform
+concern, kept as its own root so its state and blast radius stay small.
+
+## Why a dedicated identity (distinct from `github-ci/`)
+
+`github-ci/` mints a read-only identity (`ObjectStorageReadOnly`) for the bucket
+smoke test — too narrow to run Terraform against the cluster. Rather than widen
+that identity, `terraform-ci/` is its **own** IAM application + policy + key +
+state, so:
+
+- Revoking the terraform-ci key has **no blast radius** on the read-only key, and
+  vice versa.
+- The two keys carry **distinct credential names** — see [Credential naming](#credential-naming).
+
+## Why a static key and not OIDC
+
+The ideal flow would be **keyless GitHub-OIDC → Scaleway** (GitHub mints a
+short-lived OIDC token, Scaleway trades it for temporary credentials, no
+long-lived secret). **This is not possible today**: Scaleway IAM is not an OIDC
+relying party — the IAM API exposes only API keys, SSH keys, SAML SSO, SCIM and
+an internal user-session JWT. The feature request for it is still open:
+
+- https://feature-request.scaleway.com/posts/761/oidc-provider-for-external-ci-cd
+
+So we use Scaleway's supported pattern — a dedicated, least-privilege **API
+key** — and mitigate the long-lived-secret risk with least privilege and a
+dedicated, independently-revocable identity. Revisit OIDC if/when Scaleway ships
+it (see the link above).
+
+## What it creates
+
+- `scaleway_iam_application.terraform_ci` — the Terraform CI identity (name `terraform-ci`).
+- `scaleway_iam_policy.terraform_ci` — least privilege for `cluster/scaleway`,
+  all scoped to `var.project_id`:
+
+  | Permission set | Why |
+  |---|---|
+  | `ObjectStorageReadWrite` | R/W the Object Storage Terraform state backend (`terraform-state-bucket/`) |
+  | `KubernetesFullAccess` | `scaleway_k8s_cluster` + `scaleway_k8s_pool` |
+  | `VPCFullAccess` | `scaleway_vpc_private_network` |
+
+  The Kubernetes/Helm providers authenticate via the cluster kubeconfig and the
+  Infisical provider via its own creds, so neither needs an IAM permission set.
+  The `ObjectStorageReadWrite` set also covers `terraform plan`/`apply` reading
+  and writing this root's own remote state.
+- `scaleway_iam_api_key.terraform_ci` — the API key for that application, with
+  `default_project_id` baked in. The org enforces an expiry on every key, so
+  `time_rotating.api_key` drives `expires_at` (default 365 days,
+  `var.api_key_rotation_days`) and rotates the key on the next apply after it
+  lapses — see [Rotation / revocation](#rotation--revocation).
+- `infisical_secret.tf_scw_access_key` / `infisical_secret.tf_scw_secret_key` —
+  the key written into Infisical (env `staging`, folder `/ci` by default) as
+  `TF_SCW_ACCESS_KEY` / `TF_SCW_SECRET_KEY`. The secret half is
+  Terraform-`sensitive`; it's never printed or committed (state-only).
+
+State lives at `terraform-ci/...` in the shared S3 bucket — independent from
+`github-ci/` and `cluster/scaleway/`.
+
+> **Note on the shared `/ci` Infisical folder:** both `github-ci/` and
+> `terraform-ci/` declare an `infisical_secret_folder.ci` for the same `/ci`
+> path. They keep separate state and write **different** secret names
+> (`SCW_*` vs `TF_SCW_*`), so there's no key collision. If `github-ci/` has
+> already created `/ci`, simply `terraform import` the existing folder into this
+> root (or let the apply reconcile it) — the secrets are the real payload.
+
+## Credential naming
+
+Distinct names keep the two identities unambiguous wherever they're consumed:
+
+| Identity | Permissions | GitHub secret names |
+|---|---|---|
+| `github-ci/` (read-only smoke test) | `ObjectStorageReadOnly` | `SCW_ACCESS_KEY` / `SCW_SECRET_KEY` |
+| `terraform-ci/` (this root) | `ObjectStorageReadWrite` + `KubernetesFullAccess` + `VPCFullAccess` | `TF_SCW_ACCESS_KEY` / `TF_SCW_SECRET_KEY` |
+
+## Credentials
+
+Same as the other roots:
+
+- **Scaleway** provider reads creds + default region/project from the **scw CLI
+  config** (`~/.config/scw/config.yaml`).
+- **Infisical** provider authenticates via a **universal-auth machine identity**;
+  its `client_id` / `client_secret` come from `*.auto.tfvars` (per-developer,
+  gitignored — see `nico.auto.tfvars`).
+- The **S3 state backend** authenticates with AWS-style env vars derived from the
+  scw config; `mise.toml`'s `[env]` block injects them automatically under mise.
+
+## Apply
+
+```bash
+mise run terraform-ci-plan    # terraform init && plan — review first
+mise run terraform-ci-apply   # terraform apply (billable: creates an IAM key)
+```
+
+> Never `terraform apply`/`destroy` here without explicit approval.
+
+After apply, the access key is an output and both halves are in Infisical.
+
+## Wiring the GitHub secrets (manual)
+
+Automating the Infisical → GitHub push is deferred (it'd mean adding a GitHub
+token to this bootstrap). For now, set the two secrets by hand. Read the values
+straight out of the Terraform state/output and Infisical — **don't paste them
+into your shell history or echo them**.
+
+The consuming workflows (#29) are split: `terraform-apply.yml` runs in the gated
+`scaleway` GitHub **Environment**, but the **destroy** workflows are ungated and
+read **repo-level** secrets. So set the pair in **both** scopes:
+
+```bash
+# 1) Environment-scoped (for terraform-apply.yml, gated on `scaleway`):
+gh secret set TF_SCW_ACCESS_KEY \
+  --repo IntegratedDynamic/infrastructure --env scaleway \
+  --body "$(terraform -chdir=terraform-ci output -raw access_key)"
+
+gh secret set TF_SCW_SECRET_KEY \
+  --repo IntegratedDynamic/infrastructure --env scaleway \
+  --body "$(terraform -chdir=terraform-ci state show -no-color scaleway_iam_api_key.terraform_ci \
+            | awk '/secret_key/ {print $3; exit}' | tr -d '\"')"
+
+# 2) Repo-level (for the ungated destroy workflows):
+gh secret set TF_SCW_ACCESS_KEY \
+  --repo IntegratedDynamic/infrastructure \
+  --body "$(terraform -chdir=terraform-ci output -raw access_key)"
+
+gh secret set TF_SCW_SECRET_KEY \
+  --repo IntegratedDynamic/infrastructure \
+  --body "$(terraform -chdir=terraform-ci state show -no-color scaleway_iam_api_key.terraform_ci \
+            | awk '/secret_key/ {print $3; exit}' | tr -d '\"')"
+```
+
+(Or copy the secret from Infisical → `staging` → `/ci` → `TF_SCW_SECRET_KEY` and
+pipe it into `gh secret set ... < /dev/stdin`.)
+
+## Verify end to end
+
+The smoke-test job in `.github/workflows/scaleway-auth-check.yml`
+(`list-state-bucket-terraform-ci`) authenticates with `TF_SCW_ACCESS_KEY` /
+`TF_SCW_SECRET_KEY` and lists the fr-par Object Storage buckets (where the
+Terraform state backend lives) — confirming the `ObjectStorageReadWrite` grant
+resolves. It triggers on any PR touching `terraform-ci/**` or the workflow
+itself, so you can validate before merge.
+
+So the validation order is: `apply` → `gh secret set` (above) → push the branch /
+re-run the PR check. A green run means real authentication succeeded.
+
+## Rotation / revocation
+
+The API key lives entirely in this root's state.
+
+- **Automatic** — `time_rotating.api_key` expires the key after
+  `var.api_key_rotation_days` (default 365). Once that window lapses, the next
+  `terraform apply` rolls the expiry forward, which (since `expires_at` is
+  ForceNew) creates fresh key material.
+- **On demand** — force it early with:
+
+  ```bash
+  terraform -chdir=terraform-ci apply -replace=scaleway_iam_api_key.terraform_ci
+  ```
+
+Either way the key material changes, so **re-run the `gh secret set` steps above**
+afterwards in **both** scopes (the Infisical copies update automatically; the
+GitHub secrets don't).
+
+To kill access entirely, destroy the application (revokes the key) — but mind
+that any workflow depending on it will start failing.

--- a/terraform-ci/main.tf
+++ b/terraform-ci/main.tf
@@ -1,0 +1,90 @@
+# Dedicated, least-privilege identity for the Terraform CI/CD pipeline to
+# authenticate to Scaleway and run `terraform apply/destroy` on cluster/scaleway.
+# This is distinct from the read-only github-ci/ identity: it has its own
+# application, policy, key and state, so it can be rotated/revoked in isolation.
+#
+# The keyless GitHub-OIDC -> Scaleway flow isn't possible yet (Scaleway IAM is
+# not an OIDC relying party — see README), so we use Scaleway's supported
+# pattern: a scoped, independently-revocable API key consumed from GH secrets.
+
+resource "scaleway_iam_application" "terraform_ci" {
+  name        = "terraform-ci"
+  description = "Terraform CI/CD for the IntegratedDynamic/infrastructure repo — applies cluster/scaleway (managed by terraform: terraform-ci/)."
+}
+
+# Least privilege for `cluster/scaleway`, scoped to a single project:
+#   ObjectStorageReadWrite — R/W the S3 Terraform state backend
+#   KubernetesFullAccess   — scaleway_k8s_cluster + scaleway_k8s_pool
+#   VPCFullAccess          — scaleway_vpc_private_network
+# The Kubernetes/Helm providers authenticate via the cluster kubeconfig and the
+# Infisical provider via its own creds, so neither needs an IAM permission set.
+resource "scaleway_iam_policy" "terraform_ci" {
+  name           = "terraform-ci-cluster-management"
+  description    = "Object Storage R/W + Kubernetes + VPC for the Terraform CI application, project-scoped."
+  application_id = scaleway_iam_application.terraform_ci.id
+
+  rule {
+    project_ids          = [var.project_id]
+    permission_set_names = ["ObjectStorageReadWrite"]
+  }
+
+  rule {
+    project_ids          = [var.project_id]
+    permission_set_names = ["KubernetesFullAccess"]
+  }
+
+  rule {
+    project_ids          = [var.project_id]
+    permission_set_names = ["VPCFullAccess"]
+  }
+}
+
+# The org enforces an expiry on every API key, and `expires_at` is ForceNew, so
+# the key inherently rotates when the expiry moves. time_rotating makes that
+# concrete and self-renewing: the timestamp holds steady until the window
+# elapses, then the next apply pushes it forward and rotates the key (re-run
+# `gh secret set` afterwards — see README).
+resource "time_rotating" "api_key" {
+  rotation_days = var.api_key_rotation_days
+}
+
+resource "scaleway_iam_api_key" "terraform_ci" {
+  application_id = scaleway_iam_application.terraform_ci.id
+  description    = "Consumed from GitHub Actions secrets (TF_SCW_ACCESS_KEY / TF_SCW_SECRET_KEY)."
+
+  # Bakes the project into the key so the state backend and Scaleway resources
+  # resolve the right scope without the workflow passing a project ID.
+  default_project_id = var.project_id
+
+  expires_at = time_rotating.api_key.rotation_rfc3339
+}
+
+# ── Write the key into Infisical ────────────────────────────────────────────
+# GitHub secrets themselves are still set manually via `gh secret set` (see
+# README) — automating that push is deferred to avoid a GitHub token here.
+
+# infisical_secret does not create missing folders, so the CI folder must exist
+# first. var.infisical_folder_path is "/<name>"; create that name under root.
+resource "infisical_secret_folder" "ci" {
+  project_id       = var.infisical_workspace_id
+  environment_slug = var.infisical_env_slug
+  folder_path      = "/"
+  name             = trimprefix(var.infisical_folder_path, "/")
+  description      = "CI secrets for GitHub Actions (shared /ci folder)."
+}
+
+resource "infisical_secret" "tf_scw_access_key" {
+  name         = "TF_SCW_ACCESS_KEY"
+  value        = scaleway_iam_api_key.terraform_ci.access_key
+  env_slug     = var.infisical_env_slug
+  workspace_id = var.infisical_workspace_id
+  folder_path  = infisical_secret_folder.ci.path
+}
+
+resource "infisical_secret" "tf_scw_secret_key" {
+  name         = "TF_SCW_SECRET_KEY"
+  value        = scaleway_iam_api_key.terraform_ci.secret_key
+  env_slug     = var.infisical_env_slug
+  workspace_id = var.infisical_workspace_id
+  folder_path  = infisical_secret_folder.ci.path
+}

--- a/terraform-ci/outputs.tf
+++ b/terraform-ci/outputs.tf
@@ -1,0 +1,11 @@
+output "application_id" {
+  description = "IAM application ID backing the Terraform CI identity."
+  value       = scaleway_iam_application.terraform_ci.id
+}
+
+# The access key is a public identifier (like an AWS access key ID), so it's safe
+# to surface. The secret half is never output — read it from Infisical or state.
+output "access_key" {
+  description = "TF_SCW_ACCESS_KEY for the CI identity (public identifier)."
+  value       = scaleway_iam_api_key.terraform_ci.access_key
+}

--- a/terraform-ci/variables.tf
+++ b/terraform-ci/variables.tf
@@ -1,0 +1,45 @@
+# Infisical universal-auth machine identity (per-developer, from nico.auto.tfvars).
+# Used to write the generated API key back into Infisical.
+variable "infisical_client_id" {
+  type = string
+}
+
+variable "infisical_client_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "infisical_workspace_id" {
+  description = "Infisical project (workspace) ID the CI secrets are written to."
+  type        = string
+  default     = "7ecb6ed4-058a-46cd-ac9f-7e792469cf0f"
+}
+
+variable "infisical_env_slug" {
+  description = "Infisical environment slug the CI secrets live in."
+  type        = string
+  default     = "staging"
+}
+
+variable "infisical_folder_path" {
+  description = "Infisical folder the CI secrets are written to (kept separate from the cluster bootstrap secrets)."
+  type        = string
+  default     = "/ci"
+}
+
+# The default project shares the organization's UUID on Scaleway. The state
+# bucket, Kubernetes clusters and VPC networks the CI identity must manage live
+# here, so we scope the policy and the API key to it.
+variable "project_id" {
+  description = "Scaleway project the terraform-ci identity is scoped to (state bucket, K8s, VPC)."
+  type        = string
+  default     = "6283c05b-a4c7-4f83-a75f-83adad236d54"
+}
+
+# Scaleway's org policy requires every API key to carry an expiry. This drives
+# the key's expires_at; once the window elapses, the next apply rotates the key.
+variable "api_key_rotation_days" {
+  description = "Lifetime (days) of the CI API key before terraform rotates it on the next apply."
+  type        = number
+  default     = 365
+}

--- a/terraform-ci/version.tf
+++ b/terraform-ci/version.tf
@@ -1,0 +1,40 @@
+terraform {
+  # Remote state in the org-wide bucket (terraform-state-bucket/). Creds: see mise.toml.
+  # Independent state from github-ci/ and cluster/scaleway/: revoking the
+  # terraform-ci key has no blast radius on the read-only github-ci identity.
+  backend "s3" {
+    bucket               = "id-terraform-state20260612164136440800000001"
+    region               = "eu-west-3"
+    workspace_key_prefix = "terraform-ci"
+    key                  = "terraform.tfstate"
+    encrypt              = true
+    use_lockfile         = true
+  }
+
+  required_providers {
+    scaleway = {
+      source  = "scaleway/scaleway"
+      version = "~> 2.0"
+    }
+    infisical = {
+      source  = "infisical/infisical"
+      version = "~> 0.16"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.12"
+    }
+  }
+}
+
+# Creds, region and project_id come from the scw CLI config (like the other roots).
+provider "scaleway" {}
+
+provider "infisical" {
+  auth = {
+    universal = {
+      client_id     = var.infisical_client_id
+      client_secret = var.infisical_client_secret
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The existing `github-ci/` Scaleway IAM identity has only `ObjectStorageReadOnly` — fine for the bucket-listing smoke test, but it cannot run `terraform apply/destroy` against `cluster/scaleway` (K8s clusters, node pools, VPC networks, Terraform state R/W). A dedicated, scoped identity is the prerequisite for the Terraform CI workflows (#29).

Scaleway IAM is not an OIDC relying party today ([feature request](https://feature-request.scaleway.com/posts/761/oidc-provider-for-external-ci-cd)), so this follows the same static-key + time-rotation pattern as `github-ci/`.

## Changes

- **New `terraform-ci/` root module** (own state, own blast radius — distinct from `github-ci/`):
  - `version.tf` — Scaleway Object Storage backend, independent state key `terraform-ci/terraform.tfstate`; providers `scaleway` / `infisical` / `time` (mirrors `github-ci/`).
  - `variables.tf` — same variables as `github-ci/`.
  - `main.tf` — `scaleway_iam_application.terraform_ci` (name `terraform-ci`); `scaleway_iam_policy.terraform_ci` granting exactly `ObjectStorageReadWrite` + `KubernetesFullAccess` + `VPCFullAccess`, each scoped to `var.project_id`; `time_rotating.api_key` (default 365 days); `scaleway_iam_api_key.terraform_ci`; Infisical secrets `TF_SCW_ACCESS_KEY` / `TF_SCW_SECRET_KEY` (secret half `sensitive`) written to `/ci`.
  - `outputs.tf` — exposes `access_key` (public id) only; never the secret.
  - `README.md` — purpose, why static key (no OIDC), resources, credential naming (`TF_SCW_*` vs read-only `SCW_*`), apply steps, `gh secret set` for the `scaleway` Environment **and** repo-level (ungated destroy workflows), rotation procedure.
  - `.terraform.lock.hcl` — `darwin_arm64` + `linux_amd64`.
  - `nico.auto.tfvars` — gitignored (`*.auto.tfvars` already covered by root `.gitignore`).
- **`mise.toml`** — `terraform-ci-init` / `terraform-ci-plan` / `terraform-ci-apply` tasks; `terraform-ci` added to `lock`.
- **`terraform-lock.yml`** — `terraform-ci` added to the matrix.
- **`scaleway-auth-check.yml`** — new `list-state-bucket-terraform-ci` job authenticating with `TF_SCW_*` and listing the state bucket (exercises `ObjectStorageReadWrite`); triggers on `terraform-ci/**` PRs.

## How to verify

- `terraform fmt -check`, `validate` (with `-backend=false`), and `actionlint` all pass locally.
- Lock file covers both platforms; the `Verify Terraform Lock Files` check re-locks and asserts no drift.
- The `list-state-bucket-terraform-ci` smoke test will fail until the manual post-merge steps below set `TF_SCW_*` (this is expected pre-apply).

## Manual post-merge steps (NOT done here)

- `mise run terraform-ci-apply` (creates a billable IAM key).
- `gh secret set TF_SCW_ACCESS_KEY` / `TF_SCW_SECRET_KEY` for the `scaleway` Environment and repo-level (see `terraform-ci/README.md`).

> Note: the local `version.tf` mirrors `main`'s `github-ci/` Scaleway Object Storage backend (not the AWS S3 variant on the unmerged `feat/migrate-to-s3` branch).

Closes #28