### PR TITLE
feat: seed ESO Infisical secret-zero (Terraform)

### DIFF
--- a/01-iam/bootstrap/infisical/main.tf
+++ b/01-iam/bootstrap/infisical/main.tf
@@ -54,3 +54,55 @@ resource "infisical_project_identity" "github_actions" {
     },
   ]
 }
+
+resource "infisical_identity" "kubernetes" {
+  name   = "kubernetes"
+  org_id = var.org_id
+
+  # Org-level role is no-access on purpose: this identity draws its actual
+  # permissions from the project membership below, never org-wide.
+  role = "no-access"
+}
+
+resource "infisical_project_identity" "kubernetes" {
+  project_id  = "7ecb6ed4-058a-46cd-ac9f-7e792469cf0f"
+  identity_id = infisical_identity.kubernetes.id
+  roles = [
+    {
+      role_slug = "member"
+    }
+  ]
+}
+
+resource "infisical_identity_universal_auth" "kubernetes" {
+  identity_id = infisical_identity.kubernetes.id
+}
+
+resource "infisical_identity_universal_auth_client_secret" "kubernetes" {
+  identity_id = infisical_identity.kubernetes.id
+}
+
+resource "infisical_secret_folder" "kubernetes" {
+  project_id       = "7ecb6ed4-058a-46cd-ac9f-7e792469cf0f"
+  environment_slug = "staging"
+  folder_path      = "/"
+  name             = "kubernetes"
+  description      = "Kubernetes credentials granting access to Infisical."
+}
+
+
+resource "infisical_secret" "kubernetes_client_id" {
+  name         = "INFISICAL_UNIVERSAL_AUTH_CLIENT_ID"
+  value        = infisical_identity_universal_auth_client_secret.kubernetes.client_id
+  env_slug     = "staging"
+  workspace_id = "7ecb6ed4-058a-46cd-ac9f-7e792469cf0f" # Project ID
+  folder_path  = "/kubernetes"
+}
+
+resource "infisical_secret" "kubernetes_client_secret" {
+  name         = "INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET"
+  value        = infisical_identity_universal_auth_client_secret.kubernetes.client_secret
+  env_slug     = "staging"
+  workspace_id = "7ecb6ed4-058a-46cd-ac9f-7e792469cf0f" # Project ID
+  folder_path  = "/kubernetes"
+}

--- a/01-iam/bootstrap/infisical/outputs.tf
+++ b/01-iam/bootstrap/infisical/outputs.tf
@@ -1,11 +1,17 @@
 # The identity ID is the principal GitHub Actions logs in as (the OIDC login call
 # takes identityId). Public identifier — safe to surface and wire into CI.
-output "identity_id" {
+output "github" {
   description = "Infisical identity ID GitHub Actions authenticates as via OIDC."
-  value       = infisical_identity.github_actions.id
+  value       = {
+    identity_id = infisical_identity.github_actions.id
+    identity_auth_id = infisical_identity_oidc_auth.github_actions.id
+  }
 }
 
-output "oidc_auth_id" {
-  description = "ID of the OIDC auth configuration attached to the identity."
-  value       = infisical_identity_oidc_auth.github_actions.id
+output "kubernetes" {
+  description = "Infisical identity ID for Kubernetes ESO."
+  value       = {
+    identity_id = infisical_identity.kubernetes.id
+    identity_auth_id = infisical_identity_universal_auth.kubernetes.id
+  }
 }

--- a/02-cluster/scaleway/external-secrets.tf
+++ b/02-cluster/scaleway/external-secrets.tf
@@ -1,0 +1,36 @@
+# External Secrets Operator (ESO) "secret-zero".
+#
+# ESO can't fetch its own Infisical auth from Infisical via itself, so Terraform
+# — which already has Infisical access — seeds that one credential here. This is
+# the *only* ESO-related thing Terraform owns: the Infisical universal-auth
+# clientId/clientSecret, in a Kubernetes Secret the ESO ClusterSecretStore reads.
+#
+# ESO itself (the controller + CRDs) is deployed by ArgoCD from the gitops repo
+# (platform/scaleway), not from here — Terraform stays a one-time bootstrapper.
+# Once ESO is up and authenticated via this secret, every other cluster secret
+# flows from Infisical through ExternalSecret resources.
+#
+# Creds come from data.infisical_secrets.infisical (folder /kubernetes), written
+# there by 01-iam/bootstrap/infisical (the "kubernetes" machine identity).
+
+resource "kubernetes_namespace" "external_secrets" {
+  metadata {
+    name = "external-secrets"
+  }
+
+  depends_on = [scaleway_k8s_pool.default]
+}
+
+resource "kubernetes_secret" "infisical_universal_auth" {
+  metadata {
+    name      = "infisical-universal-auth"
+    namespace = kubernetes_namespace.external_secrets.metadata[0].name
+  }
+
+  type = "Opaque"
+
+  data = {
+    clientId     = data.infisical_secrets.infisical.secrets["INFISICAL_UNIVERSAL_AUTH_CLIENT_ID"].value
+    clientSecret = data.infisical_secrets.infisical.secrets["INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET"].value
+  }
+}

--- a/02-cluster/scaleway/main.tf
+++ b/02-cluster/scaleway/main.tf
@@ -59,3 +59,10 @@ resource "null_resource" "update_kubeconfig" {
     EOT
   }
 }
+
+
+data "infisical_secrets" "infisical" {
+  env_slug     = "staging"
+  workspace_id = "7ecb6ed4-058a-46cd-ac9f-7e792469cf0f" // project ID
+  folder_path  = "/kubernetes"
+}


### PR DESCRIPTION
## Context
Adding External Secrets Operator. ESO is deployed by ArgoCD (see companion PR in `gitops`); Terraform only seeds the one credential ESO can't source from itself — its Infisical universal-auth creds. No bootstrap cycle: ArgoCD boots from its Terraform-seeded admin password + the public gitops repo, ESO comes up after and fills in everything else.

## Changes
- `02-cluster/scaleway/external-secrets.tf` — `external-secrets` namespace + `infisical-universal-auth` Secret, fed from `data.infisical_secrets.infisical` (folder `/kubernetes`).
- `01-iam/bootstrap/infisical/` — `kubernetes` machine identity (universal auth) whose `client_id`/`client_secret` are written into `/kubernetes`.
- `02-cluster/scaleway/main.tf` — datasource exposing those creds to TF.

## Companion
gitops `feature/external-secrets-operator` (ESO chart + ClusterSecretStore).

## Test
`terraform -chdir=02-cluster/scaleway validate` ✅. Full path: apply provisions the cluster, ArgoCD bootstraps, then the gitops ESO app authenticates via this Secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)