### PR TITLE
feat(argocd): authenticate via shared Dex instead of embedded Dex

### DIFF
--- a/02-cluster/scaleway/argocd.tf
+++ b/02-cluster/scaleway/argocd.tf
@@ -48,6 +48,12 @@ configs:
       # carries the app.kubernetes.io/part-of: argocd label ArgoCD requires
       # for custom secret references.
       clientSecret: $argocd-oidc-client-secret:oidc.clientSecret
+      # `argocd login --sso` talks to Dex directly (PKCE, no client
+      # secret) rather than through argocd-server's own /auth/callback —
+      # it can't use the confidential `argocd` client above, so it gets
+      # its own public client (gitops repo: platform/scaleway/dex.yml,
+      # staticClients.argocd-cli).
+      cliClientID: argocd-cli
       requestedScopes:
         - openid
         - profile

--- a/02-cluster/scaleway/argocd.tf
+++ b/02-cluster/scaleway/argocd.tf
@@ -31,6 +31,38 @@ configs:
   params:
     server.insecure: true
 
+  cm:
+    url: https://argocd.scalepack.fr
+
+    # Native OIDC against our own shared Dex (platform/scaleway/dex.yml in
+    # the gitops repo, staticClients.argocd) instead of the chart's built-in
+    # Dex (disabled below) — one Dex instance for the whole platform, one
+    # place the GitHub org/team restriction is defined.
+    oidc.config: |
+      name: Dex
+      issuer: https://auth.scalepack.fr
+      clientID: argocd
+      # Resolved from the argocd-oidc-client-secret Secret (gitops repo:
+      # apps/argocd-config), not the default argocd-secret — that secret
+      # carries the app.kubernetes.io/part-of: argocd label ArgoCD requires
+      # for custom secret references.
+      clientSecret: $argocd-oidc-client-secret:oidc.clientSecret
+      requestedScopes:
+        - openid
+        - profile
+        - email
+        - groups
+
+  rbac:
+    policy.csv: |
+      g, IntegratedDynamic:admins, role:admin
+    policy.default: role:readonly
+
+# The chart's own embedded Dex is redundant now that ArgoCD talks OIDC
+# directly to our shared Dex — turned off rather than run two.
+dex:
+  enabled: false
+
 controller:
   replicas: 1
 

--- a/02-cluster/scaleway/argocd.tf
+++ b/02-cluster/scaleway/argocd.tf
@@ -19,13 +19,6 @@ resource "helm_release" "argocd" {
 
   depends_on = [scaleway_k8s_pool.default]
 
-  set_sensitive = [{
-    name = "configs.secret.argocdServerAdminPassword"
-    # ArgoCD require a `bcrypt()` hashed password here. But `bcrypt` generate a new hash at each execution
-    # So instead, we store the hash directly, so terraform is not confused anymore by fake changes
-    value = var.argocd_admin_password_hash
-  }]
-
   values = [<<EOF
 configs:
   params:
@@ -33,6 +26,14 @@ configs:
 
   cm:
     url: https://argocd.scalepack.fr
+
+    # Local admin login is redundant now that OIDC via Dex is working —
+    # one login path, no separate password to rotate/leak. To bring back
+    # a break-glass fallback: set this back to "true" and restore the
+    # set_sensitive block (removed in this commit — see git history) that
+    # sets configs.secret.argocdServerAdminPassword from
+    # var.argocd_admin_password_hash.
+    admin.enabled: "false"
 
     # Native OIDC against our own shared Dex (platform/scaleway/dex.yml in
     # the gitops repo, staticClients.argocd) instead of the chart's built-in

--- a/02-cluster/scaleway/argocd.tf
+++ b/02-cluster/scaleway/argocd.tf
@@ -55,7 +55,7 @@ configs:
 
   rbac:
     policy.csv: |
-      g, IntegratedDynamic:admins, role:admin
+      g, IntegratedDynamic:Admin, role:admin
     policy.default: role:readonly
 
 # The chart's own embedded Dex is redundant now that ArgoCD talks OIDC


### PR DESCRIPTION
## Summary
- Points ArgoCD's `oidc.config` at the shared Dex deployed by the gitops repo (`auth.scalepack.fr`) instead of the argo-cd chart's own bundled Dex, which is now disabled (`dex.enabled: false`).
- `argocd-rbac-cm` maps the `IntegratedDynamic:Admin` GitHub team to `role:admin`; everyone else in the org falls back to `role:readonly`.
- Disables local admin login (`admin.enabled: false`) now that OIDC is confirmed working end-to-end — no separate password to rotate/leak. Reversible (see comments in `argocd.tf`).
- Adds `cliClientID: argocd-cli` so `argocd login --sso` uses its own public Dex client instead of the confidential server-side one.

Companion gitops-repo PR (Dex static clients, ArgoCD's HTTPRoute/ExternalSecret, TLS cert cutover): IntegratedDynamic/gitops#16

## Test plan
- [x] `terraform validate` / `terraform fmt`
- [x] Verified live on scaleway: ArgoCD login via Dex/GitHub (UI + CLI `--sso`)
- [x] Verified live on scaleway: RBAC role mapping (admin team → role:admin)
- [x] Confirmed embedded Dex deployment removed, no local admin secret set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCgyeSfKWH6m5mmJEg6t43