### PR TITLE
fix(argocd): trust the letsencrypt-staging CA for OIDC

### DIFF
--- a/02-cluster/scaleway/argocd.tf
+++ b/02-cluster/scaleway/argocd.tf
@@ -59,6 +59,83 @@ configs:
         - profile
         - email
         - groups
+      # TEMPORARY: apps/gateway-config (gitops repo) runs letsencrypt-staging
+      # right now (branch fix/gateway-staging-ca — letsencrypt-prod is
+      # rate-limited until 2026-07-26 05:49 UTC), so ArgoCD's own OIDC
+      # discovery/token calls to auth.scalepack.fr would otherwise fail
+      # TLS verification the same way Grafana's did (confirmed live there:
+      # "x509: certificate signed by unknown authority"). rootCA is
+      # ArgoCD's native per-provider CA override for exactly this case.
+      # Extracted from the live scalepack-fr-wildcard-tls Secret's served
+      # chain (intermediate + cross-signed root), same bundle used for
+      # Grafana's tls_client_ca and OpenBao's oidc_discovery_ca_pem.
+      # Remove once back on letsencrypt-prod.
+      rootCA: |
+        -----BEGIN CERTIFICATE-----
+        MIIFDjCCAvagAwIBAgIQP62QbC8DAdGNbaR7NzBv3jANBgkqhkiG9w0BAQsFADBD
+        MQswCQYDVQQGEwJVUzENMAsGA1UEChMESVNSRzElMCMGA1UEAxMcKFNUQUdJTkcp
+        IFlvbmRlciBZYW0gUm9vdCBZUjAeFw0yNTA5MDMwMDAwMDBaFw0yODA5MDIyMzU5
+        NTlaMEoxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MSMwIQYD
+        VQQDExooU1RBR0lORykgRXJzYXR6IEVtbWVyIFlSMjCCASIwDQYJKoZIhvcNAQEB
+        BQADggEPADCCAQoCggEBALVKXXQ+HfIdsroHx2TzhU3yBaocETY0MRoMHnS8CXUd
+        X3GYyVh/rHVgbiN3Kl8uBUl9PULcgNL5ltGEaPbQpQ6Ydb3SCAUTkJYySlJRFTdd
+        VnreV5Rv+zkcwWiyCVxjT1q10MDHQwIqKzfQqNK0bPn/RTUMgdGREPZsDdHaRjNS
+        t3zTECX/UUkeKSGwRqQLmdpmT0cV1XgUnNdCSeZoChX/WGTy5ntWD7ejHUo/KQG5
+        bhbD+XZ7Lm7us4Q5eBa10wgF9n7Q5JK/ZzwJ3Hx/o889zV+ZOlxWiQJi2K4E0DM9
+        Oj3hPPHW6NEWNjVqvDOWd8WqlgrM06JKWukGgZzzieECAwEAAaOB9jCB8zAOBgNV
+        HQ8BAf8EBAMCAYYwEwYDVR0lBAwwCgYIKwYBBQUHAwEwEgYDVR0TAQH/BAgwBgEB
+        /wIBADAdBgNVHQ4EFgQURf/2+BQuZ/bfqVTyRaVnwNZqg2wwHwYDVR0jBBgwFoAU
+        ULHXmAJQX9syRhtYwWhAciRvSsEwNgYIKwYBBQUHAQEEKjAoMCYGCCsGAQUFBzAC
+        hhpodHRwOi8vc3RnLXlyLmkubGVuY3Iub3JnLzATBgNVHSAEDDAKMAgGBmeBDAEC
+        ATArBgNVHR8EJDAiMCCgHqAchhpodHRwOi8vc3RnLXlyLmMubGVuY3Iub3JnLzAN
+        BgkqhkiG9w0BAQsFAAOCAgEAhUIaqp4M/cqLqKqb5zyG9kJkGYzOWq2YHV558vCK
+        CeLDkc12Jlll7u+AqkfkqwnLmqUHolHPQFNdL6HPW+f9lX68Kv4kaznRT7rxqXbX
+        xWO5ylgpJibwDKmVt581OcyhleZ8fajL2LfcDbY24ivsWOwlKevbLBV2C+HKS+IM
+        yvKxJovnbQsd2NfEiizPfrHXJAqyOv49yYeeE+eorvQHe8HJrNrYVjSs6PI51dbv
+        Lac6+SwfiwbtGZqddS7t8IY+IfOksamRe78s4kiA99nLOEGrQXhxNZIryngqL8p8
+        FKIi4UIC4Jez5wF8aSS/SG5IhCGbixgSYj/NpttpHOuWQFij54/eaFC8JXgDXafz
+        +XXFuuTXpEzQdD0exRnRj5DU0GUR174KagSiYgK2ND0RAPMkwtdOND+2wCN6UC5x
+        9fAjsDETMOe0aDAA1MKITiZ27MAxvxIDuAqTcVKYLu8NA37r2oC0k8ucAipMSUxt
+        OYQ03+hl+7GCx14j9LYYG3PfVt/qD5wsp6ys2GcJX0GPj2FziTs0FoIb1zrKTD1v
+        66xRtYZJIJmFfeSeZf7D0UcD3YA5Mbjmuz/6h43mws2nG/ZHbwPOtZV2N4cbXszu
+        fEciE157FGkWTBabn3GeUd2uyMvuhbPKM6UajJ4TyjFBM8AVZyNPFR0IqRLZX64h
+        DS4=
+        -----END CERTIFICATE-----
+        -----BEGIN CERTIFICATE-----
+        MIIGKDCCBBCgAwIBAgIRAKYOL1Z3OCaTuowlAS/mVJgwDQYJKoZIhvcNAQELBQAw
+        ZjELMAkGA1UEBhMCVVMxMzAxBgNVBAoTKihTVEFHSU5HKSBJbnRlcm5ldCBTZWN1
+        cml0eSBSZXNlYXJjaCBHcm91cDEiMCAGA1UEAxMZKFNUQUdJTkcpIFByZXRlbmQg
+        UGVhciBYMTAeFw0yNjA1MTMwMDAwMDBaFw0zMjA5MDIyMzU5NTlaMEMxCzAJBgNV
+        BAYTAlVTMQ0wCwYDVQQKEwRJU1JHMSUwIwYDVQQDExwoU1RBR0lORykgWW9uZGVy
+        IFlhbSBSb290IFlSMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAtp7v
+        6tBp9gDpiGVLOjMs1eS9DgItpgFU9ReJwb/Sygs6q+6EUCxfi5qDOKkDldiVOtlj
+        uwAFv8621qM4ukY6OmRBIA9hnCuunJlKNEjQfWArqwMOoo5iLZ4pq0UP4htWJluk
+        OoVorSouK/3E1XWTR3ZwImIofC0+p2203TpDbThhgPzT/ZjvMUE24qQTBcQtJ8wI
+        J7nz/k6B/NyM2+GmEMNFF11BtbUamVFJXMRi+KZeRoK/bQTAjePpY/0B1DDcqgQc
+        wCb3sIOj5ysFUK7qJyca8Xk5bF8wFOFxGHKmRRPrMpb7tXdTXHlSymDCtUx98CCf
+        wpr+7+vnHgaqsW5Yfr3AGt9P5SL+3hcmww4j0Xx6B3E4m0E+8g9mtJ1L1k7Caapw
+        geRW0ghidKJmN+5gY3p2G7P8Hq4yWC+fmJy1OWCg6GDwZmCMQu/AMUawRV40AUYZ
+        ZYBAeobZU/uKcmbWKUXuak1baZWp7oqjcsIDKxbMkg6KGjhLbVchHcYUslCoL+Aj
+        ShfAA3n8WJ0cjU3p+BMkWjTKVuAfLYN/DA76CvfRWX02D+riGz3VsFXCw9k5mFE0
+        zm+Vhc8xI3TWNhU6Qm6R1KrgCU2qOpgaJ8RlokUK3QFWrIdOAIQwO0leeyjTd/Me
+        vsw62Bzg0rbQ1kS3h+eWBcBskNCFJKDujztGeCcCAwEAAaOB8zCB8DAOBgNVHQ8B
+        Af8EBAMCAQYwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUwAwEB/zAd
+        BgNVHQ4EFgQUULHXmAJQX9syRhtYwWhAciRvSsEwHwYDVR0jBBgwFoAUtfNl8v6w
+        CpIf+zx980SgrGMlwxQwNgYIKwYBBQUHAQEEKjAoMCYGCCsGAQUFBzAChhpodHRw
+        Oi8vc3RnLXgxLmkubGVuY3Iub3JnLzATBgNVHSAEDDAKMAgGBmeBDAECATArBgNV
+        HR8EJDAiMCCgHqAchhpodHRwOi8vc3RnLXgxLmMubGVuY3Iub3JnLzANBgkqhkiG
+        9w0BAQsFAAOCAgEAaqpAP+MTuFW+J0X2ibDAFe2QBUxEVzxUri7lDLII/lcXkL93
+        Vzu/fsfZL/D730It62cTSvVojEpBWP9AqGkVlldOjpKU2xag1D41CoRvkdgfFOd0
+        ezk8afg6mDHv+aBnHr49AL7xb5SC3GUqj+bn5HURBQcGZJJhhTjzET4Wj1lQSZbP
+        DqlS2WOxLiLnf5+EOVGjouJmJwFoodGOhEpAVxBWUY8B/9OGMzGAMBYeLMlEm4WV
+        NO4J7URT4AL2+i+WAK/qhpVrl6Zc+x/NPcRbW3qm9xFwgqdNXxcDgPktWwVyEhlg
+        3L9JrQ7y0s0b/or9Nbzj/Fng82IAputPDTMRHFRcsK2X7rShg2slHpWRrajd/j+u
+        xmHm/x84V0I1MVqMKkPEW5PBkmoJICt5GtSX7UkI4NVGFDo8IFG/eTIFSEkCvBq5
+        XEvE5lebNoFNSNKs7DfA6mhEpFmTJVONehdvRjPssmyTq21lY7w/9/4HTF2bEq8g
+        G6dRn2ZJgqfmUxnBun2JdAADXArYsh1BkRtWQN+JjQIjiMNO3AhmHOXmkkW2gww2
+        w8aH4OfRCndYYtw5Y60X9gNcpMRZOE2JjQG3ECZZb6EY5SEwPG+QxcRDOdQjZ4S6
+        jgKO5JRQNGcnvW8cVYK5AMjgRGZE6V9IxECMeEwNEFA17qGcweG1Tb3IpYs=
+        -----END CERTIFICATE-----
 
   rbac:
     policy.csv: |

--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ Cette commande installe toutes les dépendances du projet définies dans `mise.t
 
 Cela configure les git hooks locaux pour automatiser les vérifications avant les commits/pushes.
 
+### Daily login (quick reference)
+
+Once onboarded, these are the two logins to redo regularly (not one-time setup) —
+both expire, so run them again whenever a command starts failing with an auth error:
+
+```bash
+# Terraform state (S3 backend) — needed before any terraform command. TTL ~ a few hours.
+aws sso login --profile infrastructure
+
+# OpenBao CLI (bao) — needed to read/write secrets directly with `bao kv ...`.
+# Requires BAO_ADDR pointed at the exposed UI (export BAO_ADDR="https://openbao.scalepack.fr/").
+# Token TTL is short (role-dependent, ~1h for the admin role) — relogin when it expires.
+bao login -method=oidc
+```
+
 ### Login with your credentials
 
 > Skip 2 and more if you only need local environment. 1 is kept because right now, Infisical SSO features are PayGated, but allow long lived credentials within your environment. All hail long lived credentials! (Don't forget to look into your own local secret encryption solution to avoid storing them in clear. In my case, macOS built-in's `security` binary is enough. See https://dev.to/alsaheem/how-to-store-secrets-in-the-mac-keychain-and-use-them-like-environment-variables-1aj7).
@@ -41,7 +56,7 @@ Cela configure les git hooks locaux pour automatiser les vérifications avant le
 
     Why AWS S3? It's extremely cheap, great DevX for mono storage management (fine grained IAM policies) and AWS includes free SSO setup for devops without friction. And Scaleway doesn't provide OIDC yet, which I do favor when it comes to CI runners, especially for such high-risk files.
 
-    Run `aws sso login`. This needs to be done daily and at bootstrap before running any terraform command locally, or state fetch will fail. 
+    Run `aws sso login --profile infrastructure`. This needs to be done daily and at bootstrap before running any terraform command locally, or state fetch will fail. 
 
     #### AWS SSO first setup: 
 


### PR DESCRIPTION
## Summary
- Companion to gitops repo's `fix/gateway-staging-ca` PR: `apps/gateway-config` currently runs `letsencrypt-staging` (prod is rate-limited until 2026-07-26 05:49 UTC).
- ArgoCD's own OIDC discovery/token exchange calls to `auth.scalepack.fr` fail TLS verification against the staging-signed cert — same failure mode confirmed live on Grafana (`x509: certificate signed by unknown authority`).
- Adds `oidc.config`'s native `rootCA` field (ArgoCD's documented per-provider CA override) with the intermediate + cross-signed root actually served by the live `scalepack-fr-wildcard-tls` cert chain — same bundle used for Grafana's `tls_client_ca` and OpenBao's `oidc_discovery_ca_pem`.
- Also includes the daily-login README addition from earlier (aws sso login / bao login), unrelated but was sitting uncommitted.
- **Note:** `02-cluster/scaleway/main.tf`'s node pool autoscaling change is a separate in-progress edit of Nicolas's, deliberately left out of this PR/commit.

TEMPORARY — revert once back on `letsencrypt-prod`.

## Test plan
- [x] `terraform validate`
- [ ] Apply, confirm `argocd login --sso` / UI OIDC login works while on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCgyeSfKWH6m5mmJEg6t43