### PR TITLE
feat(scaleway): enable autoscaling on the default node pool

### DIFF
--- a/02-cluster/scaleway/main.tf
+++ b/02-cluster/scaleway/main.tf
@@ -23,9 +23,9 @@ resource "scaleway_k8s_pool" "default" {
   name        = "default"
   node_type   = "DEV1-M"
   size        = var.node_count
-  min_size    = 0
+  min_size    = 1
   max_size    = 3
-  autoscaling = false
+  autoscaling = true
   autohealing = true
 
   lifecycle {


### PR DESCRIPTION
## Summary
- `min_size` 0 → 1, `autoscaling` false → true on the scaleway default node pool.
- Was sitting uncommitted in the working tree — likely your response to this week's resource-pressure incidents (Grafana/Prometheus contention on a fixed 2-node DEV1-M pool, nodes observed at 92-101% memory during OIDC testing).

## Test plan
- [ ] `terraform plan`/`apply` to confirm Scaleway accepts the pool update in place (no node replacement expected for this field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCgyeSfKWH6m5mmJEg6t43