### PR TITLE
feat: scale staging node pool to 2 nodes

### DIFF
--- a/02-cluster/scaleway/env/02-cluster-staging.tfvars
+++ b/02-cluster/scaleway/env/02-cluster-staging.tfvars
@@ -1,1 +1,2 @@
 cluster_name = "scaleway-homelab"
+node_count = 2

--- a/02-cluster/scaleway/main.tf
+++ b/02-cluster/scaleway/main.tf
@@ -22,6 +22,8 @@ resource "scaleway_k8s_pool" "default" {
   cluster_id  = scaleway_k8s_cluster.this.id
   name        = "default"
   node_type   = "DEV1-M"
+  # Put whatever number is required to avoid node pressure signals during startup: https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/
+  # Node pressure during startup can end-up with unexcepted race conditions.
   size        = var.node_count
   min_size    = 1
   max_size    = 3


### PR DESCRIPTION
## Summary
- Set `node_count = 2` for the `02-cluster-staging` Scaleway workspace
- Document why the pool size matters: avoids node-pressure eviction races during pool startup

## Test plan
- [ ] `terraform plan` on `02-cluster/scaleway` with the `02-cluster-staging` workspace shows only the pool size change
- [ ] CI plan/apply workflow passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BL4VrtkHLq4UxBFPSBYYrU