### PR TITLE
refactor: read cross-root secrets via terraform_remote_state

### DIFF
--- a/05-secrets/openbao/managed/variables.tf
+++ b/05-secrets/openbao/managed/variables.tf
@@ -1,14 +1,3 @@
-variable "approle_role_id" {
-  description = "role_id of the `terraform` AppRole (output of 05-secrets/openbao/bootstrap)."
-  type        = string
-}
-
-variable "approle_secret_id" {
-  description = "secret_id of the `terraform` AppRole (output of 05-secrets/openbao/bootstrap)."
-  type        = string
-  sensitive   = true
-}
-
 # --- Full contents of every kv/apps/* secret object this root reconciles.
 # Some fields are arbitrary (Terraform could generate them) and some are
 # externally issued (GitHub App/OAuth credentials) — both kinds live in these

--- a/05-secrets/openbao/managed/version.tf
+++ b/05-secrets/openbao/managed/version.tf
@@ -20,6 +20,22 @@ terraform {
   }
 }
 
+# role_id/secret_id for the `terraform` AppRole — read straight from
+# 05-secrets/openbao/bootstrap's own state instead of a hand-copied variable.
+# Safe to reference from the provider block below: this data source has no
+# dependency on the vault provider itself (it's a plain S3 backend read), so
+# there's no ordering cycle — same category of pattern as
+# 10-cluster/scaleway/version.tf's kubernetes/helm providers reading straight
+# off a resource attribute.
+data "terraform_remote_state" "openbao_bootstrap" {
+  backend = "s3"
+  config = {
+    bucket = "id-terraform-state20260612164136440800000001"
+    region = "eu-west-3"
+    key    = "secrets/bootstrap/openbao/05-secrets-openbao/terraform.tfstate"
+  }
+}
+
 # Authenticates as the `terraform` AppRole from 05-secrets/openbao/bootstrap —
 # this root is the machine identity that role exists for. Address hardcoded,
 # not read from VAULT_ADDR: OpenBao's own CLI populates BAO_ADDR/BAO_TOKEN,
@@ -27,13 +43,16 @@ terraform {
 # the bootstrap root's version.tf/README for the incident this came from).
 provider "vault" {
   address = "https://openbao.scalepack.fr/"
+
+  # Alternative URL when something goes wrong with public connection
+  # Requires Kubernetes permissions to run `kubectl port-forward -n openbao openbao-0 8200:8200`
   # address = "http://127.0.0.1:8200/"
 
   auth_login {
     path = "auth/approle/login"
     parameters = {
-      role_id   = var.approle_role_id
-      secret_id = var.approle_secret_id
+      role_id   = data.terraform_remote_state.openbao_bootstrap.outputs.role_id
+      secret_id = data.terraform_remote_state.openbao_bootstrap.outputs.secret_id
     }
   }
 }

--- a/10-cluster/local/main.tf
+++ b/10-cluster/local/main.tf
@@ -9,6 +9,29 @@ locals {
   argocd_password_hash = var.argocd_admin_password_hash != "" ? var.argocd_admin_password_hash : data.infisical_secrets.this[0].secrets["ArgoCD_admin_encrypted"].value
 }
 
+# scaleway-s3-credentials source: 03-storage/scaleway's "backup" bucket + its
+# scoped workload identity. Same remote state key 05-secrets/openbao/managed
+# reads as its own `backup_scaleway` data source.
+data "terraform_remote_state" "backup_scaleway" {
+  backend = "s3"
+  config = {
+    bucket = "id-terraform-state20260612164136440800000001"
+    region = "eu-west-3"
+    key    = "backup/scaleway/03-backup-dev-bucket/terraform.tfstate"
+  }
+}
+
+# AWS credentials OpenBao reads at startup for KMS auto-unseal (seal "awskms")
+# — source: 02-encryption/aws's KMS key + dedicated IAM user.
+data "terraform_remote_state" "openbao_unseal_aws" {
+  backend = "s3"
+  config = {
+    bucket = "id-terraform-state20260612164136440800000001"
+    region = "eu-west-3"
+    key    = "openbao-unseal/aws/03-backup-dev-bucket/terraform.tfstate"
+  }
+}
+
 resource "kubernetes_namespace" "openbao" {
   metadata {
     name = "openbao"
@@ -22,18 +45,17 @@ resource "kubernetes_secret" "scaleway_s3_credentials" {
   }
 
   data = {
-    bucket     = "backup-dev-id"
-    AWS_ACCESS_KEY_ID = "SCW8FGA70P4HY3A120KV"
-    AWS_SECRET_ACCESS_KEY = var.scaleway_s3_secret_key
+    bucket                 = data.terraform_remote_state.backup_scaleway.outputs.bucket_name
+    AWS_ACCESS_KEY_ID      = data.terraform_remote_state.backup_scaleway.outputs.workload_access_key
+    AWS_SECRET_ACCESS_KEY  = data.terraform_remote_state.backup_scaleway.outputs.workload_secret_key
   }
 }
 
 # AWS credentials OpenBao reads at startup for KMS auto-unseal (seal "awskms").
 # Sourced here — outside OpenBao — by necessity: OpenBao can't supply the very
-# creds it needs to unseal itself (chicken-and-egg). Values come from the
-# 02-encryption/aws kms outputs, fed via the gitignored *.auto.tfvars.
-# Key names (access_key/secret_key) mirror scaleway-s3-credentials so the
-# OpenBao chart's extraSecretEnvironmentVars mapping stays uniform.
+# creds it needs to unseal itself (chicken-and-egg). Key names (access_key/
+# secret_key) mirror scaleway-s3-credentials so the OpenBao chart's
+# extraSecretEnvironmentVars mapping stays uniform.
 resource "kubernetes_secret" "openbao_unseal_aws" {
   metadata {
     name      = "openbao-unseal-aws"
@@ -41,8 +63,8 @@ resource "kubernetes_secret" "openbao_unseal_aws" {
   }
 
   data = {
-    AWS_ACCESS_KEY_ID = var.openbao_unseal_aws_access_key_id
-    AWS_SECRET_ACCESS_KEY = var.openbao_unseal_aws_secret_access_key
+    AWS_ACCESS_KEY_ID = data.terraform_remote_state.openbao_unseal_aws.outputs.openbao_unseal_access_key_id
+    AWS_SECRET_ACCESS_KEY = data.terraform_remote_state.openbao_unseal_aws.outputs.openbao_unseal_secret_access_key
   }
 }
 

--- a/10-cluster/local/variables.tf
+++ b/10-cluster/local/variables.tf
@@ -17,23 +17,3 @@ variable "argocd_admin_password_hash" {
   # default     = ""
 }
 
-variable "scaleway_s3_secret_key" {
-  description = "Scaleway S3 secret key for OpenBao backup bucket"
-  type        = string
-  sensitive   = true
-  # default     = ""
-}
-
-variable "openbao_unseal_aws_access_key_id" {
-  description = "AWS access key id OpenBao uses for KMS auto-unseal. From 02-encryption/aws output `openbao_unseal_access_key_id`."
-  type        = string
-  sensitive   = true
-  # default     = ""
-}
-
-variable "openbao_unseal_aws_secret_access_key" {
-  description = "AWS secret access key OpenBao uses for KMS auto-unseal. From 02-encryption/aws output `openbao_unseal_secret_access_key`."
-  type        = string
-  sensitive   = true
-  # default     = ""
-}

--- a/10-cluster/scaleway/main.tf
+++ b/10-cluster/scaleway/main.tf
@@ -63,6 +63,29 @@ resource "null_resource" "update_kubeconfig" {
 }
 
 
+# scaleway-s3-credentials source: 03-storage/scaleway's "backup" bucket + its
+# scoped workload identity. Same remote state key 05-secrets/openbao/managed
+# reads as its own `backup_scaleway` data source.
+data "terraform_remote_state" "backup_scaleway" {
+  backend = "s3"
+  config = {
+    bucket = "id-terraform-state20260612164136440800000001"
+    region = "eu-west-3"
+    key    = "backup/scaleway/03-backup-dev-bucket/terraform.tfstate"
+  }
+}
+
+# AWS credentials OpenBao reads at startup for KMS auto-unseal (seal "awskms")
+# — source: 02-encryption/aws's KMS key + dedicated IAM user.
+data "terraform_remote_state" "openbao_unseal_aws" {
+  backend = "s3"
+  config = {
+    bucket = "id-terraform-state20260612164136440800000001"
+    region = "eu-west-3"
+    key    = "openbao-unseal/aws/03-backup-dev-bucket/terraform.tfstate"
+  }
+}
+
 resource "kubernetes_namespace" "openbao" {
   metadata {
     name = "openbao"
@@ -77,18 +100,17 @@ resource "kubernetes_secret" "scaleway_s3_credentials" {
   }
 
   data = {
-    bucket     = "backup-dev-id"
-    AWS_ACCESS_KEY_ID = "SCW8FGA70P4HY3A120KV"
-    AWS_SECRET_ACCESS_KEY = var.scaleway_s3_secret_key
+    bucket                 = data.terraform_remote_state.backup_scaleway.outputs.bucket_name
+    AWS_ACCESS_KEY_ID      = data.terraform_remote_state.backup_scaleway.outputs.workload_access_key
+    AWS_SECRET_ACCESS_KEY  = data.terraform_remote_state.backup_scaleway.outputs.workload_secret_key
   }
 }
 
 # AWS credentials OpenBao reads at startup for KMS auto-unseal (seal "awskms").
 # Sourced here — outside OpenBao — by necessity: OpenBao can't supply the very
-# creds it needs to unseal itself (chicken-and-egg). Values come from the
-# 02-encryption/aws kms outputs, fed via the gitignored *.auto.tfvars.
-# Key names (access_key/secret_key) mirror scaleway-s3-credentials so the
-# OpenBao chart's extraSecretEnvironmentVars mapping stays uniform.
+# creds it needs to unseal itself (chicken-and-egg). Key names (access_key/
+# secret_key) mirror scaleway-s3-credentials so the OpenBao chart's
+# extraSecretEnvironmentVars mapping stays uniform.
 resource "kubernetes_secret" "openbao_unseal_aws" {
   metadata {
     name      = "openbao-unseal-aws"
@@ -96,7 +118,7 @@ resource "kubernetes_secret" "openbao_unseal_aws" {
   }
 
   data = {
-    AWS_ACCESS_KEY_ID = var.openbao_unseal_aws_access_key_id
-    AWS_SECRET_ACCESS_KEY = var.openbao_unseal_aws_secret_access_key
+    AWS_ACCESS_KEY_ID = data.terraform_remote_state.openbao_unseal_aws.outputs.openbao_unseal_access_key_id
+    AWS_SECRET_ACCESS_KEY = data.terraform_remote_state.openbao_unseal_aws.outputs.openbao_unseal_secret_access_key
   }
 }

--- a/10-cluster/scaleway/variables.tf
+++ b/10-cluster/scaleway/variables.tf
@@ -57,23 +57,3 @@ variable "argocd_admin_password_hash" {
   # default     = ""
 }
 
-variable "scaleway_s3_secret_key" {
-  description = "Scaleway S3 secret key for OpenBao backup bucket"
-  type        = string
-  sensitive   = true
-  # default     = ""
-}
-
-variable "openbao_unseal_aws_access_key_id" {
-  description = "AWS access key id OpenBao uses for KMS auto-unseal. From 02-encryption/aws output `openbao_unseal_access_key_id`."
-  type        = string
-  sensitive   = true
-  # default     = ""
-}
-
-variable "openbao_unseal_aws_secret_access_key" {
-  description = "AWS secret access key OpenBao uses for KMS auto-unseal. From 02-encryption/aws output `openbao_unseal_secret_access_key`."
-  type        = string
-  sensitive   = true
-  # default     = ""
-}


### PR DESCRIPTION
## Summary
- `approle_role_id`/`approle_secret_id` (`05-secrets/openbao/managed`), the KMS unseal AWS keypair, and the backup bucket S3 credentials/bucket name (`10-cluster/local`, `10-cluster/scaleway`) were hand-copied once into gitignored `*.auto.tfvars` from another root's `terraform output` and never re-derived.
- Read them straight off the owning root's state instead, via `data.terraform_remote_state` — same pattern already used for `dns_scaleway`/`backup_scaleway` in `05-secrets/openbao/managed`.
- Also drops two bare string literals (`bucket = "backup-dev-id"`, `AWS_ACCESS_KEY_ID = "SCW8FGA70P4HY3A120KV"`) that weren't even variables.
- Out of scope (confirmed): anything genuinely external and not Terraform-derivable — GitHub App/OAuth creds, Infisical creds, the OpenBao root token, `argocd_admin_password_hash`.

## Test plan
- [x] `terraform validate` passes on all three touched roots
- [x] Every new `data.terraform_remote_state` block resolves correctly (plan showed no diff on the data source reads themselves)
- [x] Live-tested on a full `10-cluster/scaleway` restart: `bao status` on `openbao-0` shows `Sealed: false` / `Seal Type: awskms` — confirms the unseal creds sourced from `02-encryption/aws` state are valid
- [x] `openbao-init-restore` job logs show a successful snapshot download from the backup bucket — confirms the S3 creds sourced from `03-storage/scaleway` state are valid
- [x] All 21 ArgoCD Applications `Synced`/`Healthy` post-restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ywVH2Xdgo3QJLSueh2k2B