### PR TITLE
fix: give ArgoCD real resource requests/limits

### DIFF
--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -154,27 +154,34 @@ dex:
 # fresh scaleway-homelab boot piles ~30 pods onto one node's worth of real
 # RAM and OOMs (see gitops repo's services/platform/cert-manager/applications/scaleway/chart.vendor.yaml
 # for the fix applied to the rest of the platform, same reasoning here).
-# controller and repoServer get the most headroom: controller watches the
-# live state of every resource this whole GitOps repo manages, and
-# repoServer's memory/CPU scales with whatever chart it's rendering at that
-# moment (kube-prometheus-stack is the largest one synced here) — both spike
-# well above their steady-state idle footprint.
+#
+# Sized from `kubectl top pods -n argocd` on the live cluster (2026-08-11,
+# two samples ~15min apart), not from chart-doc guesses — a first pass
+# anchored on generic recommendations instead of this cluster's actual
+# usage left controller's limit (512Mi) barely above its observed 405-471Mi,
+# no real headroom at all. controller is the standout: it watches the live
+# state of every resource this whole GitOps repo manages, so its memory
+# scales with total tracked resource count, not just "idle controller
+# usage" — request is set above the observed band, limit well above it.
+# repoServer's memory/CPU spikes with whatever chart it's rendering at that
+# moment (kube-prometheus-stack is the largest one synced here), hence the
+# same generous limit despite low observed idle usage (8m/131Mi).
 controller:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 50m
+      memory: 512Mi
     limits:
       cpu: 1000m
-      memory: 512Mi
+      memory: 1024Mi
 
 repoServer:
   replicas: 1
   resources:
     requests:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 25m
+      memory: 192Mi
     limits:
       cpu: 1000m
       memory: 768Mi
@@ -182,29 +189,29 @@ repoServer:
 server:
   resources:
     requests:
-      cpu: 50m
+      cpu: 10m
       memory: 64Mi
     limits:
-      cpu: 200m
+      cpu: 100m
       memory: 128Mi
 
 redis:
   resources:
     requests:
-      cpu: 50m
+      cpu: 10m
       memory: 64Mi
     limits:
-      cpu: 200m
+      cpu: 100m
       memory: 128Mi
 
 applicationSet:
   resources:
     requests:
-      cpu: 25m
-      memory: 32Mi
+      cpu: 10m
+      memory: 64Mi
     limits:
       cpu: 100m
-      memory: 64Mi
+      memory: 128Mi
 
 notifications:
   resources:

--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -147,11 +147,73 @@ configs:
 dex:
   enabled: false
 
+# Chart ships resources: {} for every component below by default —
+# confirmed live 2026-08-11: with every platform chart requestless (this
+# one included), the scheduler has nothing to balance the pool's 2 nodes on
+# and Cluster Autoscaler never sees a reason to reach for the 3rd, so a
+# fresh scaleway-homelab boot piles ~30 pods onto one node's worth of real
+# RAM and OOMs (see gitops repo's services/platform/cert-manager/applications/scaleway/chart.vendor.yaml
+# for the fix applied to the rest of the platform, same reasoning here).
+# controller and repoServer get the most headroom: controller watches the
+# live state of every resource this whole GitOps repo manages, and
+# repoServer's memory/CPU scales with whatever chart it's rendering at that
+# moment (kube-prometheus-stack is the largest one synced here) — both spike
+# well above their steady-state idle footprint.
 controller:
   replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 512Mi
 
 repoServer:
   replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 768Mi
+
+server:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+redis:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+applicationSet:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+
+notifications:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 50m
+      memory: 64Mi
 EOF
   ]
 }


### PR DESCRIPTION
## Summary
- ArgoCD's own components (`controller`, `repoServer`, `server`, `redis`, `applicationSet`, `notifications`) ship `resources: {}` by default in argo-helm — this root's `helm_release.argocd` never overrode that.
- Confirmed live 2026-08-11 on a fresh `scaleway-homelab` boot: without real requests anywhere in the platform, kube-scheduler has no signal to balance the pool's 2 nodes, and Cluster Autoscaler never sees a Pending pod to justify reaching for the 3rd node — one node ended up with 31 pods vs 12, hit `MemoryPressure`, and started evicting/crashlooping workloads.
- Companion PR in `gitops`: IntegratedDynamic/gitops#23 — same fix applied to every other platform chart (cert-manager, external-dns, external-secrets, openbao, velero, wireguard).

`controller`/`repoServer` get the widest limit-over-request headroom: controller tracks the live state of everything this GitOps repo manages, and repo-server's footprint scales with whatever chart it's rendering (kube-prometheus-stack being the largest synced here).

## Test plan
- [x] `terraform fmt -check` / `terraform validate` pass on `10-cluster/scaleway`
- [x] Embedded YAML `values` heredoc extracted and parsed standalone (valid, all 6 component keys present with expected values)
- [ ] Apply on next `scaleway-up` and confirm pod distribution across nodes evens out (tracked alongside the gitops PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mqgrku7T7sfPYHvg9fmBMB