### PR TITLE
fix(openbao): manage ESO's ClusterSecretStore in Terraform, not GitOps

### DIFF
--- a/05-secrets/openbao/managed/.terraform.lock.hcl
+++ b/05-secrets/openbao/managed/.terraform.lock.hcl
@@ -1,26 +1,24 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version = "6.58.0"
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.0"
   hashes = [
-    "h1:OWl47Bo8Vzlf5srTUCmA6v4kvQGfah/P1joRtIYUUMc=",
-    "zh:1221253beee5629fb503d79cebc9bc661279cbc4be5d01db9ab4c1b702108250",
-    "zh:132bd0925bdc4b72446ac750b7ccb1e19b9ba8fbb6df57b2c1423314d2195d4f",
-    "zh:18cda250b9e82b753808715893c8927f132273c00ffae7a697d65ac1cb577e48",
-    "zh:204c944f1fb7f440a335bb2083c9691a9d1f677aea9701025dd5816aee41f0ba",
-    "zh:2dc41df289f2b10a01e650cdd73699955f0ab0645d09cfb114a8cd0f4cc4ede7",
-    "zh:345633dfa9a234659d52aadd126e6dce658518c3ab5cbf6d871221287ed5ec56",
-    "zh:4dadcced73e742903158bc9838936d911f3fa4c2c37b5591c1a28f8f2a1902a6",
-    "zh:5bc60cc2b8c093da98b211d9f6c21c9ecec0f21b944d9ecbe3961fba33086e80",
-    "zh:6cc8f084938b0033a9c0c910989919dad6b1683e76e0afa1a5c604e39f398a75",
-    "zh:7db214647f79de9a033b5dfd6cbfaa42d53c4d056b32cb3acc7ad99306dd548a",
-    "zh:9078589ec881cee7ed9403af262c98ff257fb3e1baae72ff6429a398b1c730af",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:bd5bce6aec4d4922b1127b8575688bd4bc4279670ee28d198ede404709826c7c",
-    "zh:cd900ecf56d21023873898b06e40234f3f4d350f2343b7d9b980d6c5cb604fae",
-    "zh:dbe93b276a84421026b956c3c5b4eb8897da6cbb54b93cb89f5d6ebbd30805ca",
-    "zh:f6b6c7bb2dbf04ee085e5c22f7a65b3ccaebf368ed95584dc0dfee8a22771056",
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
+    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
   ]
 }
 

--- a/05-secrets/openbao/managed/main.tf
+++ b/05-secrets/openbao/managed/main.tf
@@ -33,8 +33,7 @@ resource "vault_kubernetes_auth_backend_role" "snapshot" {
   token_ttl                        = 3600
 }
 
-# external-secrets/external-secrets — ESO's ClusterSecretStore
-# (gitops repo apps/openbao-init/templates/clustersecretstore.yaml).
+# external-secrets/external-secrets — bound to the ClusterSecretStore below.
 resource "vault_kubernetes_auth_backend_role" "external_secrets" {
   backend                          = vault_auth_backend.kubernetes.path
   role_name                        = "external-secrets"
@@ -42,6 +41,54 @@ resource "vault_kubernetes_auth_backend_role" "external_secrets" {
   bound_service_account_namespaces = ["external-secrets"]
   token_policies                   = [vault_policy.eso_read.name]
   token_ttl                        = 3600
+}
+
+# ESO's single cluster-wide entry point into OpenBao — the Kubernetes-side
+# half of the auth_backend_role above. Used to live in the gitops repo
+# (services/platform/openbao/init/templates/clustersecretstore.yaml),
+# GitOps-synced with its own ArgoCD sync-wave. Moved here 2026-08-12: that
+# wave placement was legitimately confusing to reason about (it *looked*
+# like it needed to run after ESO's own Helm chart, since ESO is the thing
+# that consumes it — actually false, but an easy trap) when in fact its only
+# real prerequisite, this exact vault_kubernetes_auth_backend_role, was
+# already Terraform-owned right here the whole time. Keeping a
+# GitOps-synced Kubernetes object pointed at a Terraform-owned prerequisite
+# it doesn't even reference by ID (the role name was a hardcoded string
+# duplicated in both places) was a code smell independent of the wave
+# ordering question. `role` below now references the resource directly —
+# one source of truth, and this object no longer has any bearing on GitOps
+# sync-wave ordering at all, since it's applied the moment this root is,
+# independent of the cluster's own ArgoCD bootstrap timing.
+#
+# Provider's own name is `vault`, not something OpenBao-specific — OpenBao
+# is a fork of Vault and speaks the same API, ESO has no dedicated provider.
+resource "kubernetes_manifest" "eso_cluster_secret_store" {
+  manifest = {
+    apiVersion = "external-secrets.io/v1"
+    kind       = "ClusterSecretStore"
+    metadata = {
+      name = "openbao"
+    }
+    spec = {
+      provider = {
+        vault = {
+          server  = "http://openbao.openbao.svc:8200"
+          path    = vault_mount.kv.path
+          version = "v2"
+          auth = {
+            kubernetes = {
+              mountPath = vault_auth_backend.kubernetes.path
+              role      = vault_kubernetes_auth_backend_role.external_secrets.role_name
+              serviceAccountRef = {
+                name      = "external-secrets"
+                namespace = "external-secrets"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 # --- OIDC auth: human login via Dex (gitops repo platform/scaleway/dex.yml,

--- a/05-secrets/openbao/managed/version.tf
+++ b/05-secrets/openbao/managed/version.tf
@@ -17,6 +17,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
   }
 }
 
@@ -64,4 +68,30 @@ provider "vault" {
       secret_id = data.terraform_remote_state.openbao_bootstrap.outputs.secret_id
     }
   }
+}
+
+# Cluster connection for this root's own `kubernetes` provider — read
+# straight off 10-cluster/scaleway's state instead of a hand-copied
+# kubeconfig, same pattern as the vault provider's AppRole creds above.
+# Needed for kubernetes_manifest.eso_cluster_secret_store in main.tf: the
+# ClusterSecretStore is the Kubernetes-side half of the
+# vault_kubernetes_auth_backend_role.external_secrets relationship this
+# root already owns the other half of — used to live in the gitops repo's
+# openbao-init chart, moved here 2026-08-12 (see main.tf's comment) so both
+# halves are managed together instead of one being GitOps-synced against a
+# prerequisite (the auth backend role) that was actually Terraform-owned
+# the whole time.
+data "terraform_remote_state" "cluster_scaleway" {
+  backend = "s3"
+  config = {
+    bucket = "id-terraform-state20260612164136440800000001"
+    region = "eu-west-3"
+    key    = "cluster/scaleway/02-cluster-staging/terraform.tfstate"
+  }
+}
+
+provider "kubernetes" {
+  host                   = data.terraform_remote_state.cluster_scaleway.outputs.cluster_host
+  token                  = data.terraform_remote_state.cluster_scaleway.outputs.cluster_token
+  cluster_ca_certificate = base64decode(data.terraform_remote_state.cluster_scaleway.outputs.cluster_ca_certificate)
 }

--- a/10-cluster/scaleway/outputs.tf
+++ b/10-cluster/scaleway/outputs.tf
@@ -1,3 +1,22 @@
 output "cluster_id" {
   value = scaleway_k8s_cluster.this.id
 }
+
+# Consumed by 05-secrets/openbao/managed's own `kubernetes` provider (via
+# terraform_remote_state, same pattern that root already uses for
+# dns_scaleway/backup_scaleway/wireguard/openbao_bootstrap) — it manages the
+# ClusterSecretStore Kubernetes object alongside the vault_kubernetes_auth_backend_role
+# it pairs with, so it needs cluster access too, without duplicating the
+# scaleway_k8s_cluster resource itself.
+output "cluster_host" {
+  value = scaleway_k8s_cluster.this.kubeconfig[0].host
+}
+
+output "cluster_ca_certificate" {
+  value = scaleway_k8s_cluster.this.kubeconfig[0].cluster_ca_certificate
+}
+
+output "cluster_token" {
+  value     = scaleway_k8s_cluster.this.kubeconfig[0].token
+  sensitive = true
+}


### PR DESCRIPTION
## Summary
- The `ClusterSecretStore` (ESO's cluster-wide entry point into OpenBao) used to live in the gitops repo's `services/platform/openbao/init` chart, GitOps-synced with its own ArgoCD wave.
- Its only real prerequisite — `vault_kubernetes_auth_backend_role.external_secrets` — was already Terraform-owned right here in `05-secrets/openbao/managed/main.tf`. Keeping the Kubernetes-side object GitOps-synced against a Terraform-owned dependency it didn't even reference by ID (the role name was a hardcoded string duplicated in both repos) was a code smell independent of wave ordering — and it made the gitops chart's own sync-wave placement legitimately confusing to reason about (looks like it needs ESO's Helm chart to run first, since ESO is the thing that *consumes* it — actually false, but an easy trap; produced two wrong wave orderings this session before landing on the actual root cause).
- Adds `kubernetes_manifest.eso_cluster_secret_store`, referencing the auth backend role directly (`vault_kubernetes_auth_backend_role.external_secrets.role_name`) instead of a duplicated string.
- This root didn't own the cluster resource itself, so it needs its own `kubernetes` provider — wired via `terraform_remote_state` off `10-cluster/scaleway`, same pattern this root's own `vault` provider already uses for its AppRole creds. `10-cluster/scaleway/outputs.tf` gains the three outputs (`cluster_host`/`cluster_token`/`cluster_ca_certificate`) that connection needs.
- Companion gitops repo change (already pushed, branch `bugfix/unify-argocd-sync-graphs`) removes `services/platform/openbao/init/templates/clustersecretstore.yaml` — that chart is now just the restore Job.

## Verification
- `terraform validate` passes.
- `.terraform.lock.hcl` regenerated for both platforms (new `kubernetes` provider added to this root) via `mise run lock`.
- Not yet `plan`/`apply`'d — this root's `vault` provider needs the WireGuard tunnel to OpenBao up, so that has to be a human-run step.

## Test plan
- [ ] Bring the tunnel up, `terraform plan` on `05-secrets/openbao/managed` — expect exactly one new resource (`kubernetes_manifest.eso_cluster_secret_store`), no changes to existing resources
- [ ] `terraform apply`, confirm the `ClusterSecretStore` exists and is `Valid`/`Ready` (`kubectl get clustersecretstore openbao`)
- [ ] On the next full cluster rebuild (gitops branch `bugfix/unify-argocd-sync-graphs`), confirm ESO's ExternalSecrets resolve correctly with no `ClusterSecretStore` object coming from ArgoCD at all

## Note
`feature/argocd-progressive-syncs` (PR #55) is now dead weight — we abandoned the RollingSync approach it enables (confirmed live it doesn't gate first-time Application creation, see gitops PR #24's history). Worth closing or stripping that PR before it's merged; didn't touch it here to keep this change scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZMCuQ5t9hdrmUctLk7hEv