### PR TITLE
fix(cluster): restore ArgoCD Application health check, raise bootstrap retry limit

### DIFF
--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -35,6 +35,37 @@ configs:
     # var.argocd_admin_password_hash.
     admin.enabled: "false"
 
+    # Without this, ArgoCD has no built-in health assessor for its own
+    # `Application` CRD — a nested Application (bootstrap/values.yaml's
+    # scalewayApps, gitops repo) is treated as "Healthy" the instant it's
+    # created with no sync error, never actually reflecting whether its own
+    # Helm release finished deploying. That silently degrades every
+    # sync-wave boundary in bootstrap/templates/scaleway.yaml from "wait for
+    # the previous wave to be ready" to "wait for the previous wave's
+    # Application objects to exist" — confirmed live 2026-08-12: wave 5
+    # (cert-manager) started ~14s after wave 4 (envoy-gateway) was created,
+    # while envoy-gateway's own chart took ~90s to actually deploy, causing
+    # a self-healing but real crash-loop race. This teaches ArgoCD to
+    # recurse into the child Application's own `.status.health` instead of
+    # defaulting to healthy-on-creation — the standard fix for this well-known
+    # "app of apps" gotcha. Health assessment of the argoproj.io/Application
+    # CRD was removed in ArgoCD 1.8; this is the documented restoration
+    # snippet:
+    # https://argo-cd.readthedocs.io/en/stable/operator-manual/health/
+    resource.customizations.health.argoproj.io_Application: |
+      hs = {}
+      hs.status = "Progressing"
+      hs.message = ""
+      if obj.status ~= nil then
+        if obj.status.health ~= nil then
+          hs.status = obj.status.health.status
+          if obj.status.health.message ~= nil then
+            hs.message = obj.status.health.message
+          end
+        end
+      end
+      return hs
+
     # Native OIDC against our own shared Dex (platform/scaleway/dex.yml in
     # the gitops repo, staticClients.argocd) instead of the chart's built-in
     # Dex (disabled below) — one Dex instance for the whole platform, one
@@ -269,6 +300,9 @@ applications:
       namespace: argocd
 
     syncPolicy:
+      # Since this application bootstrap all the gitops repo, it's equal to cluster startup duration, which is greated than default argocd timeout values.
+      retry: 
+        limit: 10 
       automated:
         prune: true
         selfHeal: true


### PR DESCRIPTION
## Summary
Companion to gitops PR [#25](https://github.com/IntegratedDynamic/gitops/pull/25) (the wave-ordering race fixes on `fix/merge-openbao-init-wave`).

- Restores ArgoCD's own documented `resource.customizations.health.argoproj.io_Application` Lua snippet. Without it, ArgoCD has no health assessor for its own `Application` CRD and treats a nested Application (every entry in `bootstrap/values.yaml`'s `scalewayApps`) as `Healthy` the instant it's created with no sync error — never reflecting whether its own Helm release actually finished deploying. That silently degraded every sync-wave boundary from "wait for the previous wave to be ready" into "wait for the previous wave's Application objects to exist," confirmed live 2026-08-12 (wave 5 started ~14s after wave 4 was merely *created*, while wave 4's own chart took ~90s to actually deploy).
- Raises the `bootstrap` Application's own `syncPolicy.retry.limit` from ArgoCD's default (5) to 10. With wave-gating now genuinely waiting for real health, a full fresh-cluster bootstrap through every wave (0-8) can take longer than 5 retries' backoff window covers — confirmed live 2026-08-13, `bootstrap` hit "retried 5 times" and gave up mid-bootstrap while `kube-prometheus-stack` was still legitimately starting up, even though every wave went healthy moments later on its own. A manual re-sync recovered it; the retry limit should cover a normal first-boot on its own.

## Test plan
- [ ] Fresh `terraform apply` of `10-cluster/scaleway` (combined with gitops PR #25)
- [ ] Confirm `bootstrap` reaches `Synced`/`Healthy` through wave 8 without a manual re-sync
- [ ] Confirm a genuinely broken child Application (e.g. a bad manifest) now surfaces as non-Healthy on the `bootstrap` app instead of being masked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZMCuQ5t9hdrmUctLk7hEv