### PR TITLE
feat: add Grafana IaC domain (06-monitoring) for MCP service account

### DIFF
--- a/05-secrets/openbao/managed/outputs.tf
+++ b/05-secrets/openbao/managed/outputs.tf
@@ -1,0 +1,13 @@
+# Read by 06-monitoring/grafana/bootstrap's own provider "grafana" block —
+# that root needs to authenticate as Grafana's admin to create its own
+# service-account trust anchor, and this root already owns that credential
+# (kv/apps/grafana/admin, see resource "vault_kv_secret_v2" "grafana_admin"
+# above). Cross-root terraform_remote_state read instead of a manually
+# re-entered value, same convention as every other cross-root credential in
+# this repo (see this file's own header comment, or 03-storage/scaleway's
+# outputs consumed just above).
+output "grafana_admin_password" {
+  description = "Grafana admin password (kv/apps/grafana/admin's admin-password field)."
+  sensitive   = true
+  value       = random_password.grafana_admin_password.result
+}

--- a/06-monitoring/README.md
+++ b/06-monitoring/README.md
@@ -1,0 +1,13 @@
+# 06-monitoring — what this domain is for
+
+Terraform-managed configuration for the monitoring stack's own tools —
+their identities and declarative config, not the tools themselves (those
+are gitops-deployed, see the gitops repo's `services/platform/monitoring/`).
+The first of CLAUDE.md's deliberately gapped `06`-`09` domain numbers.
+
+One service lives here today: [`grafana/`](grafana/README.md), split into
+two roots — `bootstrap/` mints the one service account identity everything
+else authenticates as (admin-applied, rare changes), `managed/` is
+Grafana's actual declarative configuration, reconciled via that service
+account. Read `grafana/README.md` for the actual detail (why its own
+domain, not `05-secrets/`).

--- a/06-monitoring/grafana/README.md
+++ b/06-monitoring/grafana/README.md
@@ -1,0 +1,52 @@
+# 06-monitoring/grafana — Grafana, managed by Terraform
+
+Two roots, split by who/how they're applied — same shape as
+`05-secrets/openbao/{bootstrap,managed}`:
+
+- [`bootstrap/`](bootstrap/README.md) — mints the `terraform` service
+  account identity. Human/admin-applied, rare changes.
+- [`managed/`](managed/README.md) — Grafana's actual declarative
+  configuration, reconciled via that service account.
+
+## Why its own domain, not `05-secrets/`
+
+`05-secrets/` is IaC for **OpenBao's own configuration** — its auth
+methods, mounts, policies, and secret content, nothing else. Grafana is a
+different tool with a different provider and its own lifecycle (dashboards,
+OIDC config, service accounts) — bolting it onto `05-secrets/openbao/managed`
+would blur that domain's scope the same way `02-encryption/aws` stayed out
+of `03-storage/scaleway` (different provider/pattern, not "storage").
+`06-monitoring/` is the first of CLAUDE.md's deliberately gapped `06`-`09`
+domain numbers, reserved for exactly this: a future domain that didn't
+exist when the numbering was first laid out.
+
+## Why bootstrap needs no manually-supplied secret (unlike OpenBao's `root_token`)
+
+OpenBao's own `bootstrap/` needs a human-supplied root token because
+nothing about OpenBao is Terraform state yet at that point — a genuine
+chicken-and-egg (see `../../05-secrets/openbao/README.md`'s self-init
+section). Grafana doesn't have that problem: its admin password is
+**already** Terraform-managed, by `05-secrets/openbao/managed`
+(`random_password.grafana_admin_password`) — `06-monitoring/grafana/bootstrap`
+just reads it via `data.terraform_remote_state`. No copy-pasting, no
+separate chicken-and-egg to solve.
+
+## The CI feedback loop
+
+None needed, beyond what already exists — unlike OpenBao's own `managed/`
+root (see its README's "CI feedback loop" section), nothing new has to be
+round-tripped through ESO here:
+
+- `06-monitoring/grafana/managed`'s `vault` provider reuses the *same*
+  `terraform` AppRole `05-secrets/openbao/managed` already authenticates
+  as — that loop is already closed.
+- Its `grafana` provider authenticates via a plain
+  `data.terraform_remote_state` read of `bootstrap`'s own state (an S3
+  read, not a live credential exchange) — CI already has the
+  `terraform-state-access` role for exactly this, no new secret needs to
+  reach it.
+
+So `06-monitoring/grafana/managed` is CI-appliable in principle from day
+one, same "designed for it, not yet wired to an actual workflow" status
+`05-secrets/openbao/managed` itself currently has (no `.github/workflows/*`
+references either root today — both are applied by hand for now).

--- a/06-monitoring/grafana/bootstrap/.terraform.lock.hcl
+++ b/06-monitoring/grafana/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,30 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/grafana/grafana" {
+  version     = "4.45.1"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:OzokYld3E8XJIn1OCv/QjiSkXOGgQe8nGsigm6kqXp4=",
+    "h1:lQTzJquYLYpGvGAjLEWskM46urd/Rdz0EHDZgIB1+tc=",
+    "zh:07e75aa317cdcd9d3fe8cb3ccd9cb9d11a43d310da5ded5b4d035e82775bed7e",
+    "zh:0a6514030b0951be8edae56b8f36e4687a725f603629a7f2cfc6d3cca364a149",
+    "zh:11da941ccecda89016a9684a6a4001c69245fe7792a638238e1161d2367142e2",
+    "zh:15861b29f73419363324ddfec293a6f61a367fe2c1f55b9eba458e43a5ce869c",
+    "zh:475e58167e6342f09444d39883b4fdf5cc8ba45853647994ba1326086111606e",
+    "zh:54bc774b0febce90da261fbb07a511d1c6021a5a5dc248f886b714e268eed8d7",
+    "zh:5b36c36c70477d30f55b4e37252cbbef3a35688c0d8ff84db1f1d0fec243b5cb",
+    "zh:5d59e038b40122dcc4b13a767a87f62a97d47f337b2f80aa9a01292edcd69add",
+    "zh:75335a50187238ebbf21704b3a474c646da76574e29b51ee91d92b8267d5aa59",
+    "zh:830979714fca5a7a97547c8f4e1e6c6c42fe001e0c0a8ac0cd2aa58443fac5d3",
+    "zh:9b137e30c55323c80ddf5b1c05ca3c72ae6e7bc10cca5ed8cc4440fdcbef1856",
+    "zh:9e839abcfddf1e31a6a7d9306bc4b91690c665b6d7f74a7a44970dbb4f74b9b9",
+    "zh:9f57311289b7b9e1482510f5d967021f3bf8d0576709328058bc7da8b746f5b2",
+    "zh:a1700a4aa94361c51fb1848f5c24efd151b3dac64341f5149ae4a3a1d213c814",
+    "zh:b651406c5cc1b392d5153adbfefe27f3eb6f472d2bcc1454577ea52bf912806e",
+    "zh:bb2ee69558a749fce4729163deb95d31a9ced4462b1724a168a148a3702dee70",
+    "zh:be2d194df093e466bc0e20a3064865f940dc0b7779a9ce503864237798b3b8de",
+    "zh:c4a5b2d1c1469c0eab283f4904bd1790c8dcbac72aac3c4c238e22ffe368680f",
+    "zh:d7a1646c9167c1a464566cb755697b5d212469b91d762cf153cb29c4439d3652",
+  ]
+}

--- a/06-monitoring/grafana/bootstrap/README.md
+++ b/06-monitoring/grafana/bootstrap/README.md
@@ -40,7 +40,8 @@ Terraform-managed by `05-secrets/openbao/managed`
   still narrower than the real human admin account.
 - `grafana_service_account_token.terraform` — the token, generated once at
   apply time. `seconds_to_live` from `var.service_account_token_ttl_days`
-  (default 90 days, mirrors `secret_id_ttl_days` in the OpenBao bootstrap
+  (default `0` — never expires; set a positive value to opt into rotation,
+  unlike the forced `secret_id_ttl_days` window in the OpenBao bootstrap
   root).
 
 ## Credentials

--- a/06-monitoring/grafana/bootstrap/README.md
+++ b/06-monitoring/grafana/bootstrap/README.md
@@ -1,0 +1,87 @@
+# 06-monitoring/grafana/bootstrap — Terraform identity for Grafana
+
+A standalone Terraform root that provisions the **service account identity
+`06-monitoring/grafana/managed` (and any later root) uses to manage
+Grafana's configuration** declaratively, instead of ad-hoc API calls against
+a live instance.
+
+Mirrors `05-secrets/openbao/bootstrap` exactly — read that root's README for
+the fuller rationale of the bootstrap/managed split; this one only notes
+where Grafana's story differs.
+
+## Why its own domain, not `05-secrets/`
+
+`05-secrets/` is IaC for **OpenBao's own configuration** — its auth methods,
+mounts, policies, and secret content. Grafana is a different tool with a
+different provider and its own lifecycle (dashboards, OIDC config, service
+accounts); bolting it onto `05-secrets/openbao/managed` would blur that
+domain's scope. `06-monitoring/` is the first of CLAUDE.md's deliberately
+gapped `06`-`09` domain numbers, reserved for exactly this kind of future
+addition.
+
+## Why Grafana needs no manually-supplied bootstrap secret (unlike OpenBao's `root_token`)
+
+OpenBao's bootstrap root needs a human-supplied `root_token` because nothing
+about OpenBao is Terraform state yet at that point — a genuine
+chicken-and-egg. Grafana's admin password, by contrast, is **already**
+Terraform-managed by `05-secrets/openbao/managed`
+(`random_password.grafana_admin_password`, backing `kv/apps/grafana/admin`)
+— this root just reads it via `data.terraform_remote_state` (see
+`version.tf`). No copy-pasting, no chicken-and-egg.
+
+## What it creates
+
+- `grafana_service_account.terraform` — `role = "Admin"`. Grafana's
+  service-account roles are coarse (Viewer/Editor/Admin, no fine-grained
+  per-path ACL like Vault/OpenBao policies) — creating further service
+  accounts/tokens requires Admin. Same reasoning as OpenBao's own
+  `terraform` policy getting `sudo` on `sys/mounts`/`sys/auth`: this
+  identity needs elevated rights to bootstrap structure, even though it's
+  still narrower than the real human admin account.
+- `grafana_service_account_token.terraform` — the token, generated once at
+  apply time. `seconds_to_live` from `var.service_account_token_ttl_days`
+  (default 90 days, mirrors `secret_id_ttl_days` in the OpenBao bootstrap
+  root).
+
+## Credentials
+
+- **`grafana` provider**: authenticates as Grafana's admin via basic auth
+  (`"admin:${password}"`), password read straight from
+  `05-secrets/openbao/managed`'s state — see `version.tf`. Public route
+  (`https://grafana.scalepack.fr/`): Grafana's basic-auth API path isn't
+  gated behind the shared sso-guard edge policy (gitops repo's
+  `services/platform/monitoring/grafana-gateway` deliberately bypasses it,
+  same as OpenBao's own public route), so no WireGuard tunnel is needed.
+- **S3 state backend**: same AWS-style env vars as every other root (via
+  `mise.toml`'s `[env]` block).
+
+## Apply
+
+```bash
+terraform -chdir=06-monitoring/grafana/bootstrap init
+terraform -chdir=06-monitoring/grafana/bootstrap workspace select -or-create 06-monitoring-grafana
+terraform -chdir=06-monitoring/grafana/bootstrap plan  -var-file=env/06-monitoring-grafana.tfvars
+terraform -chdir=06-monitoring/grafana/bootstrap apply -var-file=env/06-monitoring-grafana.tfvars
+```
+
+> Never `terraform apply`/`destroy` here without explicit approval.
+
+## Consuming the service account (06-monitoring/grafana/managed onward)
+
+`06-monitoring/grafana/managed`'s own `provider "grafana"` reads
+`service_account_token` straight from this root's state via
+`data.terraform_remote_state` — no manual copy-paste, same as the OpenBao
+bootstrap/managed pair.
+
+## Rotation / revocation
+
+- **Token** — force early rotation with:
+
+  ```bash
+  terraform -chdir=06-monitoring/grafana/bootstrap apply -replace=grafana_service_account_token.terraform -var-file=env/06-monitoring-grafana.tfvars
+  ```
+
+  Re-apply `06-monitoring/grafana/managed` afterward — the old token stops
+  working immediately once replaced.
+- **Full revocation** — destroy `grafana_service_account.terraform`; mind
+  that anything consuming it (currently just `managed/`) breaks immediately.

--- a/06-monitoring/grafana/bootstrap/env/06-monitoring-grafana.tfvars
+++ b/06-monitoring/grafana/bootstrap/env/06-monitoring-grafana.tfvars
@@ -1,0 +1,3 @@
+# No overrides needed yet — service_account_token_ttl_days defaults sensibly
+# (see variables.tf). This file exists to name the terraform workspace
+# ("06-monitoring-grafana"), per repo convention.

--- a/06-monitoring/grafana/bootstrap/main.tf
+++ b/06-monitoring/grafana/bootstrap/main.tf
@@ -1,0 +1,22 @@
+# Trust anchor for future Terraform-managed Grafana configuration: a service
+# account scoped to *creating further Grafana resources* (dashboards, other
+# service accounts, OIDC config, ...), not any one specific integration.
+# Mirrors 05-secrets/openbao/bootstrap's AppRole role exactly — same
+# "admin mints the one identity everything else authenticates as" pattern.
+#
+# role = "Admin": Grafana's service-account roles are coarse (Viewer/Editor/
+# Admin, no fine-grained per-path ACL like Vault/OpenBao policies) —
+# creating other service accounts/tokens requires Admin. Same reasoning as
+# OpenBao's own terraform policy getting sudo on sys/mounts/sys/auth: this
+# identity needs elevated rights to bootstrap structure, even though it's
+# still narrower than the real human admin account.
+resource "grafana_service_account" "terraform" {
+  name = "terraform"
+  role = "Admin"
+}
+
+resource "grafana_service_account_token" "terraform" {
+  name               = "terraform"
+  service_account_id = grafana_service_account.terraform.id
+  seconds_to_live    = var.service_account_token_ttl_days * 24 * 3600
+}

--- a/06-monitoring/grafana/bootstrap/outputs.tf
+++ b/06-monitoring/grafana/bootstrap/outputs.tf
@@ -1,0 +1,10 @@
+output "service_account_id" {
+  description = "Grafana service account ID for the terraform identity (public identifier)."
+  value       = grafana_service_account.terraform.id
+}
+
+output "service_account_token" {
+  description = "Grafana service account token (sensitive). Read via `terraform output -raw service_account_token` — don't paste into shell history."
+  value       = grafana_service_account_token.terraform.key
+  sensitive   = true
+}

--- a/06-monitoring/grafana/bootstrap/variables.tf
+++ b/06-monitoring/grafana/bootstrap/variables.tf
@@ -1,0 +1,9 @@
+# No built-in expiry enforced by Grafana on service account tokens by
+# default (seconds_to_live = 0/null means never expire) — this is a repo
+# convention, not a platform requirement, mirroring secret_id_ttl_days in
+# 05-secrets/openbao/bootstrap.
+variable "service_account_token_ttl_days" {
+  description = "Rotation window (days) for the terraform service account token."
+  type        = number
+  default     = 90
+}

--- a/06-monitoring/grafana/bootstrap/variables.tf
+++ b/06-monitoring/grafana/bootstrap/variables.tf
@@ -1,9 +1,9 @@
-# No built-in expiry enforced by Grafana on service account tokens by
-# default (seconds_to_live = 0/null means never expire) — this is a repo
-# convention, not a platform requirement, mirroring secret_id_ttl_days in
-# 05-secrets/openbao/bootstrap.
+# 0 = never expires (Grafana's own sentinel for seconds_to_live) — unlike
+# secret_id_ttl_days in 05-secrets/openbao/bootstrap, no forced rotation
+# window by default for this low-stakes, single-consumer identity. Set a
+# positive value here to opt into rotation.
 variable "service_account_token_ttl_days" {
-  description = "Rotation window (days) for the terraform service account token."
+  description = "Days before the terraform service account token expires. 0 = never expires."
   type        = number
-  default     = 90
+  default     = 0
 }

--- a/06-monitoring/grafana/bootstrap/version.tf
+++ b/06-monitoring/grafana/bootstrap/version.tf
@@ -1,0 +1,45 @@
+terraform {
+  backend "s3" {
+    bucket               = "id-terraform-state20260612164136440800000001"
+    region               = "eu-west-3"
+    workspace_key_prefix = "monitoring/bootstrap/grafana"
+    key                  = "terraform.tfstate"
+    encrypt              = true
+    use_lockfile         = true
+  }
+
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "~> 4.0"
+    }
+  }
+}
+
+# 05-secrets/openbao/managed's own state — read directly instead of a
+# hand-copied local.auto.tfvars value, same convention as every other
+# cross-root credential in this repo (see that root's outputs.tf,
+# grafana_admin_password). Plain S3 backend read, no provider needed for
+# this data source.
+data "terraform_remote_state" "openbao_managed" {
+  backend = "s3"
+  config = {
+    bucket = "id-terraform-state20260612164136440800000001"
+    region = "eu-west-3"
+    key    = "secrets/managed/openbao/05-secrets-openbao/terraform.tfstate"
+  }
+}
+
+# Authenticates as Grafana's own admin via basic auth — the same admin
+# credential 05-secrets/openbao/managed already generates and owns
+# (kv/apps/grafana/admin). No chicken-and-egg like OpenBao's own bootstrap
+# root_token: Grafana's admin password is already Terraform state elsewhere,
+# so this root needs zero manually-supplied secrets. Public route: Grafana's
+# basic-auth API path isn't gated behind the shared sso-guard edge policy
+# (gitops repo's services/platform/monitoring/grafana-gateway deliberately
+# bypasses it, same reasoning the OpenBao vault provider's own comment gives
+# for its public route), so no WireGuard tunnel is needed here.
+provider "grafana" {
+  url  = "https://grafana.scalepack.fr/"
+  auth = "admin:${data.terraform_remote_state.openbao_managed.outputs.grafana_admin_password}"
+}

--- a/06-monitoring/grafana/managed/.terraform.lock.hcl
+++ b/06-monitoring/grafana/managed/.terraform.lock.hcl
@@ -1,0 +1,51 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/grafana/grafana" {
+  version     = "4.45.1"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:OzokYld3E8XJIn1OCv/QjiSkXOGgQe8nGsigm6kqXp4=",
+    "h1:lQTzJquYLYpGvGAjLEWskM46urd/Rdz0EHDZgIB1+tc=",
+    "zh:07e75aa317cdcd9d3fe8cb3ccd9cb9d11a43d310da5ded5b4d035e82775bed7e",
+    "zh:0a6514030b0951be8edae56b8f36e4687a725f603629a7f2cfc6d3cca364a149",
+    "zh:11da941ccecda89016a9684a6a4001c69245fe7792a638238e1161d2367142e2",
+    "zh:15861b29f73419363324ddfec293a6f61a367fe2c1f55b9eba458e43a5ce869c",
+    "zh:475e58167e6342f09444d39883b4fdf5cc8ba45853647994ba1326086111606e",
+    "zh:54bc774b0febce90da261fbb07a511d1c6021a5a5dc248f886b714e268eed8d7",
+    "zh:5b36c36c70477d30f55b4e37252cbbef3a35688c0d8ff84db1f1d0fec243b5cb",
+    "zh:5d59e038b40122dcc4b13a767a87f62a97d47f337b2f80aa9a01292edcd69add",
+    "zh:75335a50187238ebbf21704b3a474c646da76574e29b51ee91d92b8267d5aa59",
+    "zh:830979714fca5a7a97547c8f4e1e6c6c42fe001e0c0a8ac0cd2aa58443fac5d3",
+    "zh:9b137e30c55323c80ddf5b1c05ca3c72ae6e7bc10cca5ed8cc4440fdcbef1856",
+    "zh:9e839abcfddf1e31a6a7d9306bc4b91690c665b6d7f74a7a44970dbb4f74b9b9",
+    "zh:9f57311289b7b9e1482510f5d967021f3bf8d0576709328058bc7da8b746f5b2",
+    "zh:a1700a4aa94361c51fb1848f5c24efd151b3dac64341f5149ae4a3a1d213c814",
+    "zh:b651406c5cc1b392d5153adbfefe27f3eb6f472d2bcc1454577ea52bf912806e",
+    "zh:bb2ee69558a749fce4729163deb95d31a9ced4462b1724a168a148a3702dee70",
+    "zh:be2d194df093e466bc0e20a3064865f940dc0b7779a9ce503864237798b3b8de",
+    "zh:c4a5b2d1c1469c0eab283f4904bd1790c8dcbac72aac3c4c238e22ffe368680f",
+    "zh:d7a1646c9167c1a464566cb755697b5d212469b91d762cf153cb29c4439d3652",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/vault" {
+  version     = "5.10.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:f+4Eh/Bzl1iun3tG3oCol/zsEqAwtFpl1PP59l8DL+k=",
+    "h1:lyFssgWG/91rFC++zoiJQDaqhzWieLL64bIF6+53Hq4=",
+    "zh:0de49889bc7cfb66f9004651252e4c38acb0c927335ce0cbe1ee59a576030a44",
+    "zh:1875cbcbac4bf19f2e9f9bd6f7a4589419f65969676c879b5c80ca4823818011",
+    "zh:32f51e4eae2157a3c56ff40cd72f218776a9a8cc2151a6d78a36078c87243ac7",
+    "zh:7674d317e9337da84daec86d1b4610392eb3838369198011fe79b6980acb8632",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7f9b9322cf83ea17ae218199bb9f482699e2ea481ba1c2e4c9f81dffc0e9a43c",
+    "zh:808dcb981408ef066a0c4cc412ba181924616157c29d5b404b7a5c6d6d6e7386",
+    "zh:8bbd07729da50f55606ae7a3a8ef0624ace110da31465753e5552abbde43233a",
+    "zh:9c798262c364afcef6630b2d290c19b763071c561b90cf051d87ad56b369cd89",
+    "zh:d90fcc9b1e740ee0c0ea6e123ec964f2e1cdbf65a1dba1786e65e2a827880e72",
+    "zh:f07e029e576786b6d4af488fdb7da2a4bbd0509e6dacfbd73230a1503e3c085e",
+    "zh:f2e5070b9a7fca6a0fe857db4d3df0f2a182567178058b764bdbfb4199ae113b",
+  ]
+}

--- a/06-monitoring/grafana/managed/README.md
+++ b/06-monitoring/grafana/managed/README.md
@@ -1,0 +1,89 @@
+# 06-monitoring/grafana/managed — Grafana configuration, as code
+
+Grafana's actual declarative configuration, reconciled via the `terraform`
+service account `06-monitoring/grafana/bootstrap` mints. Today that's just
+one thing (the MCP server's own service account) — this is where future
+Grafana-as-code lives: dashboards, folders, alerting, OIDC config, etc.,
+same role `05-secrets/openbao/managed` plays for OpenBao.
+
+## What it creates
+
+- `grafana_service_account.mcp_claude_code` — `role = "Editor"`, the
+  identity [`github.com/grafana/mcp-grafana`](https://github.com/grafana/mcp-grafana)
+  (the Grafana MCP server) authenticates as. Editor per that project's own
+  documented recommendation — enough for its typical toolset (dashboards,
+  datasources, alerts) without full Admin.
+- `grafana_service_account_token.mcp_claude_code` — the token, generated
+  once at apply time. `seconds_to_live` from
+  `var.mcp_service_account_token_ttl_days` (default 90 days).
+- `vault_kv_secret_v2.grafana_mcp_token` — writes the token to
+  `kv/apps/monitoring/grafana-mcp-token`. **Not** synced into the cluster by
+  anything (no ESO ExternalSecret reads this) — the only consumer is a
+  human (fetching it directly to configure the MCP server locally), same
+  rationale as `05-secrets/openbao/managed`'s `apps/wireguard/confs`. ESO
+  wouldn't help here anyway: its job is syncing into Kubernetes Secrets, and
+  the actual consumer is a local `claude mcp` process, not a cluster
+  workload.
+
+## A note on dynamic secrets
+
+A community Vault plugin exists for this
+([`Boostport/vault-plugin-secrets-grafana`](https://github.com/Boostport/vault-plugin-secrets-grafana)) —
+it would let OpenBao mint short-lived, auto-revoked Grafana tokens on demand
+instead of this root's static, Terraform-rotated one. Deliberately not
+adopted here: it still needs this same bootstrap Admin service account as
+its own backing credential, and registering a third-party (non-official)
+plugin binary is a real change to OpenBao's own deployment (gitops repo),
+not just a Terraform resource — worth a dedicated follow-up if/when this
+grows beyond one personal-use token.
+
+## Credentials
+
+- **`grafana` provider**: authenticates as the `terraform` service account
+  from `06-monitoring/grafana/bootstrap`, read via
+  `data.terraform_remote_state` — see `version.tf`.
+- **`vault` provider**: reuses the same `terraform` AppRole
+  `05-secrets/openbao/managed` itself authenticates as (its policy already
+  grants `kv/data|metadata/apps/*` broadly, so writing a new path here needs
+  no OpenBao-side policy change) — see that root's `version.tf` for the
+  address/split-DNS rationale.
+- **S3 state backend**: same AWS-style env vars as every other root (via
+  `mise.toml`'s `[env]` block).
+
+## Apply
+
+```bash
+terraform -chdir=06-monitoring/grafana/managed init
+terraform -chdir=06-monitoring/grafana/managed workspace select -or-create 06-monitoring-grafana
+terraform -chdir=06-monitoring/grafana/managed plan  -var-file=env/06-monitoring-grafana.tfvars
+terraform -chdir=06-monitoring/grafana/managed apply -var-file=env/06-monitoring-grafana.tfvars
+```
+
+> Never `terraform apply`/`destroy` here without explicit approval.
+
+## Fetching the MCP token
+
+```bash
+bao login -method=oidc   # your own OIDC admin session
+bao kv get -field=token kv/apps/monitoring/grafana-mcp-token
+```
+
+Then register the MCP server (default `local` scope — not committed to git):
+
+```bash
+claude mcp add-json "grafana" '{"command":"uvx","args":["mcp-grafana"],"env":{"GRAFANA_URL":"https://grafana.scalepack.fr/","GRAFANA_SERVICE_ACCOUNT_TOKEN":"<token>"}}'
+```
+
+## Rotation / revocation
+
+- **Token** — force early rotation with:
+
+  ```bash
+  terraform -chdir=06-monitoring/grafana/managed apply -replace=grafana_service_account_token.mcp_claude_code -var-file=env/06-monitoring-grafana.tfvars
+  ```
+
+  Bumps `data_json_wo_version` isn't needed here since the resource itself
+  is replaced (new `.key` value flows through automatically) — but re-fetch
+  the token from OpenBao afterward and re-register the MCP server, the old
+  one stops working immediately.
+- **Full revocation** — destroy `grafana_service_account.mcp_claude_code`.

--- a/06-monitoring/grafana/managed/README.md
+++ b/06-monitoring/grafana/managed/README.md
@@ -15,7 +15,8 @@ same role `05-secrets/openbao/managed` plays for OpenBao.
   datasources, alerts) without full Admin.
 - `grafana_service_account_token.mcp_claude_code` — the token, generated
   once at apply time. `seconds_to_live` from
-  `var.mcp_service_account_token_ttl_days` (default 90 days).
+  `var.mcp_service_account_token_ttl_days` (default `0` — never expires;
+  set a positive value to opt into rotation).
 - `vault_kv_secret_v2.grafana_mcp_token` — writes the token to
   `kv/apps/monitoring/grafana-mcp-token`. **Not** synced into the cluster by
   anything (no ESO ExternalSecret reads this) — the only consumer is a

--- a/06-monitoring/grafana/managed/env/06-monitoring-grafana.tfvars
+++ b/06-monitoring/grafana/managed/env/06-monitoring-grafana.tfvars
@@ -1,0 +1,3 @@
+# No overrides needed yet — mcp_service_account_token_ttl_days defaults
+# sensibly (see variables.tf). This file exists to name the terraform
+# workspace ("06-monitoring-grafana"), per repo convention.

--- a/06-monitoring/grafana/managed/main.tf
+++ b/06-monitoring/grafana/managed/main.tf
@@ -1,0 +1,29 @@
+# mcp-claude-code — the Grafana MCP server's (github.com/grafana/mcp-grafana)
+# own service account, used by Claude Code locally to query dashboards,
+# datasources, and alerts. role = "Editor" per that project's own
+# recommendation: enough for its typical toolset without full Admin.
+resource "grafana_service_account" "mcp_claude_code" {
+  name = "mcp-claude-code"
+  role = "Editor"
+}
+
+resource "grafana_service_account_token" "mcp_claude_code" {
+  name                = "mcp-claude-code"
+  service_account_id  = grafana_service_account.mcp_claude_code.id
+  seconds_to_live     = var.mcp_service_account_token_ttl_days * 24 * 3600
+}
+
+# apps/monitoring/grafana-mcp-token — deliberately NOT synced into the
+# cluster by anything (no ESO ExternalSecret reads this): the only consumer
+# is a human (me) fetching it directly from OpenBao to configure the MCP
+# server locally (`claude mcp add-json`), same rationale as
+# 05-secrets/openbao/managed's apps/wireguard/confs.
+resource "vault_kv_secret_v2" "grafana_mcp_token" {
+  mount = "kv"
+  name  = "apps/monitoring/grafana-mcp-token"
+
+  data_json_wo = jsonencode({
+    token = grafana_service_account_token.mcp_claude_code.key
+  })
+  data_json_wo_version = 1
+}

--- a/06-monitoring/grafana/managed/variables.tf
+++ b/06-monitoring/grafana/managed/variables.tf
@@ -1,0 +1,8 @@
+# No built-in expiry enforced by Grafana on service account tokens by
+# default — repo convention, mirrors service_account_token_ttl_days in
+# 06-monitoring/grafana/bootstrap.
+variable "mcp_service_account_token_ttl_days" {
+  description = "Rotation window (days) for the mcp-claude-code service account token."
+  type        = number
+  default     = 90
+}

--- a/06-monitoring/grafana/managed/variables.tf
+++ b/06-monitoring/grafana/managed/variables.tf
@@ -1,8 +1,7 @@
-# No built-in expiry enforced by Grafana on service account tokens by
-# default — repo convention, mirrors service_account_token_ttl_days in
-# 06-monitoring/grafana/bootstrap.
+# 0 = never expires (Grafana's own sentinel for seconds_to_live) — mirrors
+# service_account_token_ttl_days in 06-monitoring/grafana/bootstrap.
 variable "mcp_service_account_token_ttl_days" {
-  description = "Rotation window (days) for the mcp-claude-code service account token."
+  description = "Days before the mcp-claude-code service account token expires. 0 = never expires."
   type        = number
-  default     = 90
+  default     = 0
 }

--- a/06-monitoring/grafana/managed/version.tf
+++ b/06-monitoring/grafana/managed/version.tf
@@ -1,0 +1,71 @@
+terraform {
+  backend "s3" {
+    bucket               = "id-terraform-state20260612164136440800000001"
+    region               = "eu-west-3"
+    workspace_key_prefix = "monitoring/managed/grafana"
+    key                  = "terraform.tfstate"
+    encrypt              = true
+    use_lockfile         = true
+  }
+
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "~> 4.0"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# 06-monitoring/grafana/bootstrap's own state — the terraform service
+# account token this root authenticates as. Cross-root remote-state read,
+# not a hand-copied value, same convention as every other cross-root
+# credential in this repo.
+data "terraform_remote_state" "grafana_bootstrap" {
+  backend = "s3"
+  config = {
+    bucket = "id-terraform-state20260612164136440800000001"
+    region = "eu-west-3"
+    key    = "monitoring/bootstrap/grafana/06-monitoring-grafana/terraform.tfstate"
+  }
+}
+
+# Already a bearer-style API token (grafana_service_account_token.key) — no
+# "user:pass" formatting needed, unlike bootstrap's admin basic-auth.
+provider "grafana" {
+  url  = "https://grafana.scalepack.fr/"
+  auth = data.terraform_remote_state.grafana_bootstrap.outputs.service_account_token
+}
+
+# 05-secrets/openbao/bootstrap's own state — the SAME `terraform` AppRole
+# 05-secrets/openbao/managed itself authenticates as. Its policy already
+# grants kv/data|metadata/apps/* broadly (create/read/update/list), so
+# writing this root's own secret (apps/monitoring/grafana-mcp-token, see
+# main.tf) needs no new OpenBao-side policy — reusing the existing identity
+# is simpler than minting a second one for the same capability.
+data "terraform_remote_state" "openbao_bootstrap" {
+  backend = "s3"
+  config = {
+    bucket = "id-terraform-state20260612164136440800000001"
+    region = "eu-west-3"
+    key    = "secrets/bootstrap/openbao/05-secrets-openbao/terraform.tfstate"
+  }
+}
+
+provider "vault" {
+  # Same address/rationale as 05-secrets/openbao/managed's own vault
+  # provider — see that root's version.tf for the full split-DNS/WireGuard
+  # explanation.
+  address = "https://openbao.scalepack.fr/"
+
+  auth_login {
+    path = "auth/approle/login"
+    parameters = {
+      role_id   = data.terraform_remote_state.openbao_bootstrap.outputs.role_id
+      secret_id = data.terraform_remote_state.openbao_bootstrap.outputs.secret_id
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ terraform -chdir=02-encryption/aws                  providers lock -platform=dar
 terraform -chdir=03-storage/scaleway                providers lock -platform=darwin_arm64 -platform=linux_amd64
 terraform -chdir=04-vpn/wireguard               providers lock -platform=darwin_arm64 -platform=linux_amd64
 terraform -chdir=05-secrets/openbao/bootstrap        providers lock -platform=darwin_arm64 -platform=linux_amd64
+terraform -chdir=06-monitoring/grafana/bootstrap     providers lock -platform=darwin_arm64 -platform=linux_amd64
+terraform -chdir=06-monitoring/grafana/managed       providers lock -platform=darwin_arm64 -platform=linux_amd64
 terraform -chdir=10-cluster/local                   providers lock -platform=darwin_arm64 -platform=linux_amd64
 terraform -chdir=10-cluster/scaleway                providers lock -platform=darwin_arm64 -platform=linux_amd64
 ```
@@ -55,9 +57,11 @@ Terraform roots are organized by **domain** — the top-level folder is a numeri
 literally owns (`00-foundation`, `01-iam`, `02-encryption`...). The number
 roughly encodes apply order / blast-radius
 across domains, though it's a convention, not something any tooling enforces.
-Gaps in the sequence (`04`, `06`-`09`) are deliberate — room for future domains
+Gaps in the sequence (`04`, `07`-`09`) are deliberate — room for future domains
 without a renumbering cascade; `10-cluster` in particular was moved up from
-`02-` on purpose to free up low numbers for domains like `02-encryption`.
+`02-` on purpose to free up low numbers for domains like `02-encryption`. `06`
+was the first gap filled: `06-monitoring/` (Terraform-managed config for the
+monitoring stack's own tools — the tools themselves are gitops-deployed).
 
 The second path segment is the **cloud provider** a root targets (`aws`,
 `scaleway`) — a domain with only one provider still nests under it (e.g.
@@ -116,6 +120,14 @@ modules/
   openbao/                     # domain: OpenBao itself (bootstrap/ + managed/,
                                #   see that directory) — untouched by the
                                #   2026-07-30 buckets/IAM consolidation
+06-monitoring/
+  grafana/                     # domain: Grafana, managed by Terraform
+                               #   (bootstrap/ + managed/, same split as
+                               #   05-secrets/openbao) — its own domain
+                               #   since 05-secrets/ is scoped to OpenBao's
+                               #   own config specifically, not any tool
+                               #   that happens to need IaC. First of the
+                               #   06-09 gaps to get filled.
 10-cluster/                    # domain: the Kubernetes platform (moved up from
                                #   02- to free up low numbers for future domains)
   local/                       #   minikube — local dev and debugging. Local backend (local files)


### PR DESCRIPTION
## Summary
- New `06-monitoring/grafana/{bootstrap,managed}` roots — mirrors `05-secrets/openbao/bootstrap+managed`'s trust pattern exactly.
- `bootstrap`: mints a Grafana `terraform` Admin service account, authenticating as Grafana's admin via a password already owned by `05-secrets/openbao/managed` (read via remote state — no manually-supplied secret needed, unlike OpenBao's own `root_token` chicken-and-egg).
- `managed`: reuses that service account to create the Grafana MCP server's (`grafana/mcp-grafana`) own `Editor`-role service account, writes the resulting token to OpenBao at `apps/monitoring/grafana-mcp-token` — not ESO-synced (the consumer is a local `claude mcp` process, not a cluster workload), same rationale as `apps/wireguard/confs`.
- `06-monitoring/` is the first of CLAUDE.md's deliberately-gapped `06`-`09` domain numbers.
- Adds one new output (`grafana_admin_password`) to `05-secrets/openbao/managed` — everything else there is untouched.
- CLAUDE.md updated: directory tree, `mise run lock` command list, the "gaps" sentence.

Considered and deliberately not adopted: `Boostport/vault-plugin-secrets-grafana` (a community Vault secrets engine for dynamic Grafana tokens) — still needs this same bootstrap Admin service account as its own backing credential, and registering a third-party plugin binary is a real change to OpenBao's own deployment (gitops repo), not just Terraform. Noted as a future upgrade path in `06-monitoring/grafana/managed/README.md`.

## Test plan
- [x] `terraform validate` clean on all three touched roots (`05-secrets/openbao/managed`, `06-monitoring/grafana/bootstrap`, `06-monitoring/grafana/managed`)
- [x] `terraform providers lock -platform=darwin_arm64 -platform=linux_amd64` run for both new roots
- [ ] `terraform apply` — not yet run (cluster is down for other work); once up: apply `bootstrap` first, then `managed`, then fetch the token from OpenBao and register the MCP server (see `06-monitoring/grafana/managed/README.md`'s "Fetching the MCP token" section)