### PR TITLE
feat: provision Loki + Tempo S3 buckets/identities, OpenBao secrets, Grafana datasources

### DIFF
--- a/03-storage/scaleway/env/03-backup-dev-bucket.tfvars
+++ b/03-storage/scaleway/env/03-backup-dev-bucket.tfvars
@@ -44,4 +44,37 @@ buckets = {
     retention_days        = 30
     cold_storage_enabled  = false
   }
+  loki = {
+    bucket_name             = "monitoring-loki-dev-id"
+    identity_app_prefix     = "monitoring-loki-k8s"
+    identity_policy_prefix  = "monitoring-loki-objects"
+    identity_purpose        = "grants Loki object read/write for log chunk storage"
+    api_key_purpose         = "Loki workload credentials"
+    api_key_consumer        = "Consumed via OpenBao (kv/apps/monitoring/loki-scaleway-s3-credentials) → ESO → Kubernetes Secret"
+
+    # Same rolling-expiry shape as thanos above: log chunks age out on their
+    # own schedule (Loki's own compactor/retention config, not this bucket),
+    # so there's no value in backup/velero's versioning + GLACIER treatment —
+    # it would just keep paying to store data Loki itself considers expired.
+    # cold_storage_enabled must stay false: the module's precondition needs
+    # cold_storage_transition_days < retention_days, and the shared 90-day
+    # default would fail against this 30-day retention.
+    versioning_enabled    = false
+    retention_days        = 30
+    cold_storage_enabled  = false
+  }
+  tempo = {
+    bucket_name             = "monitoring-tempo-dev-id"
+    identity_app_prefix     = "monitoring-tempo-k8s"
+    identity_policy_prefix  = "monitoring-tempo-objects"
+    identity_purpose        = "grants Tempo object read/write for trace block storage"
+    api_key_purpose         = "Tempo workload credentials"
+    api_key_consumer        = "Consumed via OpenBao (kv/apps/monitoring/tempo-scaleway-s3-credentials) → ESO → Kubernetes Secret"
+
+    # Same reasoning as loki above: trace blocks age out per Tempo's own
+    # compactor/retention config, not this bucket's lifecycle rules.
+    versioning_enabled    = false
+    retention_days        = 30
+    cold_storage_enabled  = false
+  }
 }

--- a/03-storage/scaleway/outputs.tf
+++ b/03-storage/scaleway/outputs.tf
@@ -59,3 +59,39 @@ output "thanos_workload_secret_key" {
   description = "Secret access key for the scoped Thanos Kubernetes workload identity."
   value       = module.buckets["thanos"].secret_key
 }
+
+# ── Loki (separate bucket + identity) ─────────────────────────────────────────
+
+output "loki_bucket_name" {
+  description = "Provisioned Loki object-storage bucket name."
+  value       = module.buckets["loki"].bucket_name
+}
+
+output "loki_workload_access_key" {
+  description = "Public access key for the scoped Loki Kubernetes workload identity."
+  value       = module.buckets["loki"].access_key
+}
+
+output "loki_workload_secret_key" {
+  sensitive   = true
+  description = "Secret access key for the scoped Loki Kubernetes workload identity."
+  value       = module.buckets["loki"].secret_key
+}
+
+# ── Tempo (separate bucket + identity) ────────────────────────────────────────
+
+output "tempo_bucket_name" {
+  description = "Provisioned Tempo object-storage bucket name."
+  value       = module.buckets["tempo"].bucket_name
+}
+
+output "tempo_workload_access_key" {
+  description = "Public access key for the scoped Tempo Kubernetes workload identity."
+  value       = module.buckets["tempo"].access_key
+}
+
+output "tempo_workload_secret_key" {
+  sensitive   = true
+  description = "Secret access key for the scoped Tempo Kubernetes workload identity."
+  value       = module.buckets["tempo"].secret_key
+}

--- a/05-secrets/openbao/managed/main.tf
+++ b/05-secrets/openbao/managed/main.tf
@@ -498,3 +498,35 @@ resource "vault_kv_secret_v2" "thanos_scaleway_s3_credentials" {
   })
   data_json_wo_version = 1
 }
+
+# apps/monitoring/loki-scaleway-s3-credentials — Loki's own Object Storage
+# credentials (gitops repo services/platform/monitoring/loki-secret),
+# reshaped there into whatever Loki's S3 client expects. Separate bucket +
+# IAM key from every other tool bucket (03-storage/scaleway/env/*.tfvars'
+# loki entry) — same "one bucket, one identity, per consumer, never shared"
+# contract (03-storage/README.md) as thanos above.
+resource "vault_kv_secret_v2" "loki_scaleway_s3_credentials" {
+  mount = vault_mount.kv.path
+  name  = "apps/monitoring/loki-scaleway-s3-credentials"
+
+  data_json_wo = jsonencode({
+    SCW_ACCESS_KEY = data.terraform_remote_state.backup_scaleway.outputs.loki_workload_access_key
+    SCW_SECRET_KEY = data.terraform_remote_state.backup_scaleway.outputs.loki_workload_secret_key
+  })
+  data_json_wo_version = 1
+}
+
+# apps/monitoring/tempo-scaleway-s3-credentials — Tempo's own Object Storage
+# credentials (gitops repo services/platform/monitoring/tempo-secret). Same
+# contract as loki above: separate bucket + IAM key
+# (03-storage/scaleway/env/*.tfvars' tempo entry), never shared.
+resource "vault_kv_secret_v2" "tempo_scaleway_s3_credentials" {
+  mount = vault_mount.kv.path
+  name  = "apps/monitoring/tempo-scaleway-s3-credentials"
+
+  data_json_wo = jsonencode({
+    SCW_ACCESS_KEY = data.terraform_remote_state.backup_scaleway.outputs.tempo_workload_access_key
+    SCW_SECRET_KEY = data.terraform_remote_state.backup_scaleway.outputs.tempo_workload_secret_key
+  })
+  data_json_wo_version = 1
+}

--- a/06-monitoring/grafana/managed/main.tf
+++ b/06-monitoring/grafana/managed/main.tf
@@ -40,6 +40,94 @@ resource "grafana_data_source" "prometheus" {
   is_default  = true
 }
 
+# Loki + Tempo — same pattern as prometheus above, added alongside
+# gitops#29 (Loki/Tempo/Alloy/OTel Collector). URLs are a BEST-EFFORT GUESS
+# at the Service names gitops#29's charts will create — assumed release
+# name == chart name (loki/tempo), matching this cluster's existing
+# convention (see the prometheus datasource's own comment on how
+# `kube-prometheus-stack-prometheus` was derived) — and Loki's optional
+# nginx `gateway` disabled (querying the SingleBinary pod's own :3100
+# directly; one less pod on a pool that's already tight, per argocd.tf's
+# resource-sizing comment). NOT yet verified against a live chart the way
+# the prometheus URL was — double-check both URLs once gitops#29 actually
+# lands, same as that comment warns for its own case.
+resource "grafana_data_source" "loki" {
+  type        = "loki"
+  name        = "Loki"
+  url         = "http://loki.monitoring.svc:3100"
+  access_mode = "proxy"
+
+  # grafana_data_source_config.loki (below) manages json_data_encoded
+  # out-of-band from this resource's own plan — without ignoring it here,
+  # every subsequent plan would show spurious drift fighting that resource
+  # (documented gotcha for this exact circular-reference case:
+  # registry.terraform.io/grafana/grafana's data_source_config docs).
+  lifecycle {
+    ignore_changes = [json_data_encoded, http_headers]
+  }
+}
+
+resource "grafana_data_source" "tempo" {
+  type        = "tempo"
+  name        = "Tempo"
+  url         = "http://tempo.monitoring.svc:3200"
+  access_mode = "proxy"
+
+  lifecycle {
+    ignore_changes = [json_data_encoded, http_headers]
+  }
+}
+
+# Loki -> Tempo (click a trace ID in a log line, jump to that trace) and
+# Tempo -> Loki/Prometheus (click a trace, jump to its logs/service
+# metrics) correlation. Split into grafana_data_source_config instead of
+# setting json_data_encoded directly on the two resources above because
+# they reference each other's uid — a genuine circular dependency Terraform
+# can only resolve by decoupling the datasource's existence from its
+# cross-referencing config (same shape as the provider's own documented
+# example for this exact Loki<->Tempo pairing).
+#
+# derivedFields' matcherRegex is Grafana's own generic doc-example pattern
+# for a "trace_id"/"traceID" field in a log line — not verified against any
+# app's actual log format yet, since nothing emits trace IDs into logs
+# until gitops#29's OTel Collector + an instrumented app exist. Harmless if
+# it never matches (derived fields are opt-in navigation, not required for
+# anything else to work); revisit the regex once a real instrumented app's
+# log shape is known.
+resource "grafana_data_source_config" "loki" {
+  uid = grafana_data_source.loki.uid
+
+  json_data_encoded = jsonencode({
+    derivedFields = [
+      {
+        datasourceUid = grafana_data_source.tempo.uid
+        matcherRegex  = "[tT]race_?[iI][dD]\"?[:=]\"?(\\w+)"
+        matcherType   = "regex"
+        name          = "traceID"
+        url           = "$${__value.raw}"
+      }
+    ]
+  })
+}
+
+# Deliberately minimal: no customQuery (let Tempo build the Loki query from
+# its own default tag matching rather than a hand-written LogQL query
+# assuming label names we haven't settled on) and no tracesToMetrics/
+# serviceMap yet — serviceMap in particular needs a spanmetrics connector
+# in the OTel Collector to exist first (not in gitops#29's scope), so
+# wiring it now would point at a Prometheus metric that doesn't exist.
+resource "grafana_data_source_config" "tempo" {
+  uid = grafana_data_source.tempo.uid
+
+  json_data_encoded = jsonencode({
+    tracesToLogsV2 = {
+      datasourceUid   = grafana_data_source.loki.uid
+      filterBySpanID  = false
+      filterByTraceID = false
+    }
+  })
+}
+
 # dashboards/*.json are the exact same dashboards kube-prometheus-stack
 # 86.1.0 would otherwise auto-deploy — extracted (not hand-written) by
 # rendering services/platform/monitoring/chart with


### PR DESCRIPTION
## Context

Terraform-side prerequisites for `gitops#29` (Loki + Tempo + Alloy + OpenTelemetry Collector). Both Loki and Tempo are S3-backed natively — no Thanos-equivalent process needed, they ship object storage as their standard production backend. This PR is the credential-plumbing chain that has to exist before either can be deployed: a bucket + scoped identity each, their credentials in OpenBao, and their Grafana datasources (with trace↔log correlation wired up).

Closes #61.

## Changes

- **`03-storage/scaleway`** — `loki` + `tempo` bucket/identity entries in `var.buckets`, same one-bucket-per-tool contract as `backup`/`velero`/`thanos`. New `loki_*`/`tempo_*` outputs mirroring the existing `thanos_*` ones.
- **`05-secrets/openbao/managed`** — `vault_kv_secret_v2.loki_scaleway_s3_credentials` / `.tempo_scaleway_s3_credentials`, mirroring `thanos_scaleway_s3_credentials`.
- **`06-monitoring/grafana/managed`** — `grafana_data_source.loki` / `.tempo` mirroring the existing `prometheus` datasource, plus `grafana_data_source_config.loki` / `.tempo` wiring trace↔log correlation (Loki `derivedFields` → Tempo, Tempo `tracesToLogsV2` → Loki) via the provider's documented circular-reference pattern.

## Known gaps (flagged inline in code)

- **Loki/Tempo datasource URLs are a best-effort guess** (`http://loki.monitoring.svc:3100`, `http://tempo.monitoring.svc:3200`) — assumes release name == chart name, matching this cluster's existing convention, and Loki's gateway disabled. Not yet verified against a live chart, since `gitops#29` hasn't landed. Same spirit as the existing `prometheus` datasource's own "verified via `helm template`" comment — revisit once that PR merges.
- **Couldn't run a live `terraform plan` against `05-secrets/openbao/managed`** in this environment — the vault provider timed out on every resource in that root (pre-existing ones included), a local WireGuard reachability issue, not something introduced by this change. `terraform validate` passes; the new resources are a direct mirror of the already-applied `thanos_scaleway_s3_credentials`.

## Test plan

- [x] `terraform validate` clean on all three roots
- [x] `terraform plan` on `03-storage/scaleway`: 12 to add, 0 to change/destroy
- [x] `terraform plan` on `06-monitoring/grafana/managed` (scoped via `-target` to the 4 new resources — existing dashboard resources hit unrelated Grafana API timeouts this session): 4 to add, 0 to change/destroy
- [ ] `terraform plan` on `05-secrets/openbao/managed` — blocked on OpenBao connectivity from this machine, needs re-running from a network with the WireGuard tunnel up
- [ ] Manual apply, in order: `03-storage/scaleway` → `05-secrets/openbao/managed` → `06-monitoring/grafana/managed` (admin-applied, per this repo's convention — not run as part of this PR)
