### PR TITLE
fix: drop Loki + Tempo bucket retention to 1 day

### DIFF
--- a/03-storage/scaleway/env/03-backup-dev-bucket.tfvars
+++ b/03-storage/scaleway/env/03-backup-dev-bucket.tfvars
@@ -58,9 +58,14 @@ buckets = {
     # it would just keep paying to store data Loki itself considers expired.
     # cold_storage_enabled must stay false: the module's precondition needs
     # cold_storage_transition_days < retention_days, and the shared 90-day
-    # default would fail against this 30-day retention.
+    # default would fail against this 1-day retention.
+    #
+    # 1 day, not 30 (2026-08-15): explicit call, not the module default —
+    # matches Loki's own limits_config.retention_period
+    # (services/platform/monitoring/loki-chart in the gitops repo, same
+    # 24h) and Tempo's below, deliberately near-term-only.
     versioning_enabled    = false
-    retention_days        = 30
+    retention_days        = 1
     cold_storage_enabled  = false
   }
   tempo = {
@@ -73,8 +78,11 @@ buckets = {
 
     # Same reasoning as loki above: trace blocks age out per Tempo's own
     # compactor/retention config, not this bucket's lifecycle rules.
+    #
+    # 1 day, not 30 (2026-08-15): matches Tempo's own retention (24h,
+    # services/platform/monitoring/tempo-chart in the gitops repo).
     versioning_enabled    = false
-    retention_days        = 30
+    retention_days        = 1
     cold_storage_enabled  = false
   }
 }


### PR DESCRIPTION
## Context

Follow-up to #62 — retention was set to 30 days there, but should match what Loki/Tempo themselves retain (both 24h, gitops#30). Bucket-level lifecycle outliving the tool's own retention has no value, same reasoning already applied to Thanos's bucket.

## Changes

`03-storage/scaleway/env/03-backup-dev-bucket.tfvars` — `loki`/`tempo` entries' `retention_days`: 30 → 1.

## Test plan

- [x] `terraform plan` — clean, 0 to add, 2 to change (both `expiration.days`), 0 to destroy
- [ ] Manual apply (admin-applied, per this repo's convention)