### PR TITLE
feat: add Scaleway state backend, rehearse AWS state migration

### DIFF
--- a/00-foundation/scaleway/.terraform.lock.hcl
+++ b/00-foundation/scaleway/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.14.1"
+  constraints = "~> 0.12"
+  hashes = [
+    "h1:GJig5pIwiKDsiF73KLs7vWvDs76/x6DeNSxKrfqlA40=",
+    "h1:r93SxP++6gUlwCHDQ5OkRmcU8B0yv6ZA9nF0Dh6NJmA=",
+    "zh:0837ca5b057e5cff94dff7de2fcccafb4abaa33c45de193fe2853e684818a267",
+    "zh:15a122f72d9e0f34fc5384cc7ec089319641fee5c319748a3aa02fc42f459969",
+    "zh:342fb83093a280ea7ee0654feae1f5867c62eb8eebc1ab46f9a7ab0b4c878a62",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:99f169834d3370b8341381c6a9c7a8b01fb26027531faa38e6fb49cc23916f68",
+    "zh:9f482917c7a28cf2436578be7aa9f04f8c811aba8b5949e0223ea987a2757a91",
+    "zh:ac6b5b8732826f2d1129a8a4a038ac7a7a9ca7b77d2a4608e5703be1a1e2bff0",
+    "zh:c54782a27d58ce04f6696c6fc0b2cf1e2fba6bed239fb520521a7bce7d7193cb",
+    "zh:c8d0ddc8f575ecb44f025d54edbfe118e26397fe328a67be62325766f31eb6e7",
+    "zh:d043b96f204edd2353bf6b2a34e645ffdee2e9634d9bb747331320444810a538",
+    "zh:e32c288501ca9a6c9d22b52e839dd391fc7083d54ee6b8dc296ce0e6bd3e57ef",
+    "zh:e47fcc7bb4e9ab5cc522c3b06e4fa9c0bf94b84be8210bc6b1655c44acb2addc",
+    "zh:f61bf218322bcbe0bd2d56bba738e7fa485e9b54244e13aa12de741b37d450c0",
+  ]
+}
+
+provider "registry.terraform.io/scaleway/scaleway" {
+  version     = "2.81.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:bmNGobzQjQifbnaeAWRamQRJLcszm1OGMkesUvBjyJY=",
+    "h1:cWsiiPfCxihYXATyTiI/M0JxnXDNFXcchNSb60UOgCI=",
+    "zh:585a967339fd4e0e8cf6895a4af77f64d03d0e5fe16b5dc060110a5a1f4f4375",
+    "zh:718cb84adfd8fe5a33bae9a525c0f9d9e70ab70195d48af847d9d15c9ebac73b",
+    "zh:7a7f89e351c6625a1b4001512a3f5aa9d01fa2e6f63c7e61abe1e3d2b5f4cd24",
+    "zh:7c1167ad7c148a121730577d9fb26b67593b97c9746b2a75ceaf0aa22e222971",
+    "zh:8a0c691fb3d66bcc7a688eee0527ed1118e8196683a8385db98e9bccecf34e51",
+    "zh:8e72f654dd67bd1280048f5dc58dd7d2fa64ce5108acf55edcab60f3cee2d121",
+    "zh:a1117fb961b741b3bf4793ae8b5ff0355f370ec51edd1231bb1c564c6889aa42",
+    "zh:a444c0d5bd8a49893c81b74992446e6340cd92ec898e19925c42cbe9e339b732",
+    "zh:ad313c31572f1be4b23187ffbe8c941cd0262a9fb320c5508d28b67bea2c3f69",
+    "zh:aee9c82069f6c58597a644aff86ca488a381b6aa6109804ea472e17bedca3db6",
+    "zh:d2f78c7a8238aa17895557bea3b8bbf2ad08045fdcac4e19ab44145f4de4cc49",
+    "zh:da778130b98f508800fe42e05c9a049234fe172484147e1752570b6e7281b3c3",
+    "zh:e83eb05748d29f48ac9c3394f077dda65ff53dd268fa3787f7deb8b6fb4cc61a",
+  ]
+}

--- a/00-foundation/scaleway/README.md
+++ b/00-foundation/scaleway/README.md
@@ -1,0 +1,221 @@
+# 00-foundation/scaleway — what this domain is for
+
+A Scaleway Object Storage counterpart to `00-foundation/aws`'s S3 bucket. As
+of 2026-08-19, every root in this repo's state lives here **except**
+`00-foundation/aws` itself (which stays on AWS permanently — it IS the AWS
+bucket, see its own README). Before this migration, every root used that one
+shared AWS bucket (different `workspace_key_prefix` per root, same bucket).
+
+## Why per-root buckets, not one shared bucket
+
+The AWS foundation bucket is **one bucket, many prefixes** — every root
+writes to `<workspace_key_prefix>/<workspace>/terraform.tfstate` inside it,
+and the one `terraform-state-access` IAM role is scoped (via its policy) to
+that bucket only.
+
+Scaleway can't reproduce that isolation: IAM policy rules here scope to a
+**project**, not a bucket or an object prefix (see
+`modules/scaleway-bucket-with-identity`'s `identity_permission_set_names`
+comment — the same limitation this repo already documents elsewhere). Any
+identity granted Object Storage permissions in a project can read/write
+**every** bucket in that project regardless of prefix. A shared bucket would
+therefore give every consuming root's CI identity read/write on every other
+root's state object, with no way to scope it down further — strictly worse
+than the AWS setup's already-documented "no isolation between roots" trade-off,
+since there it's at least contained to CI-assumed-role-in-this-repo.
+
+So: **one dedicated bucket per consuming root module** (`var.state_buckets`
+below, one map entry per root), each with its **own** dedicated identity by
+default too (`create_identity = true`, see "Per-bucket identities" below) —
+it doesn't fix the underlying project-level IAM limitation (that identity
+can still technically touch every bucket in the project, Scaleway gives no
+way to scope it down further), but it at least means a bucket — and its
+identity — can be deleted/recreated/reused/revoked independently per root,
+and keeps each root's state blast radius (accidental `force_destroy`,
+lifecycle misconfig, a leaked key, etc.) confined to its own bucket. Most
+roots need exactly one bucket; a root with its own bootstrap/init concerns
+(e.g. something needing a scratch bucket before its "real" one exists) can
+get more than one entry.
+
+## Status: migration complete (2026-08-19)
+
+This root's own state is self-hosted here too
+(`state_buckets["foundation_scaleway"]`) — bootstrapped the same one-time
+chicken-and-egg way `00-foundation/aws` was: created while its state still
+lived in the AWS bucket, then repointed at itself and migrated with
+`terraform init -migrate-state`.
+
+**Rehearsal result (2026-08-18): confirmed working.** The migration procedure
+was rehearsed end to end first against a throwaway root, `99-scratch/migration-test`
+(applied against the AWS bucket, repointed at this root's
+`state_buckets["scratch"]` bucket, moved with `terraform init -migrate-state`,
+verified, then destroyed and its directory deleted from the repo — its purpose
+was purely this rehearsal). Findings:
+
+- **Locking works.** `backend "s3" { use_lockfile = true }` (conditional
+  `If-None-Match` writes) succeeded on Scaleway Object Storage — both during
+  the migration itself and on a subsequent `plan` ("Acquiring state
+  lock"/"Releasing state lock", no errors). No fallback locking strategy
+  needed.
+- **Credential wiring confirmed.** Terraform's `s3` backend authenticates
+  with `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` — the exact same env
+  vars a root's own `provider "aws"` block (if it has one, e.g.
+  `02-encryption/aws`) uses for its *real* AWS credentials. The working
+  approach: pass the Scaleway key pair via `-backend-config="access_key=..."`
+  / `-backend-config="secret_key=..."` (from a gitignored file, never
+  committed) at `terraform init`, leaving ambient `AWS_ACCESS_KEY_ID`/
+  `AWS_SECRET_ACCESS_KEY` free for a real AWS provider. Still needs
+  `.github/actions/terraform/action.yml` updated to do this for CI before any
+  such root migrates — out of scope for this rehearsal, in scope for the real
+  rollout.
+- **Endpoint/path style confirmed.** Scaleway's S3-compatible endpoint is
+  path-style (`https://s3.<region>.scw.cloud/<bucket>`, per
+  `modules/scaleway-bucket-with-identity`'s `bucket_endpoint` output), not
+  AWS's virtual-hosted style — `use_path_style = true` plus
+  `skip_s3_checksum = true` (Scaleway doesn't support the AWS SDK's newer
+  default PutObject checksum) were both required. The working `backend "s3"`
+  block (now gone along with the deleted rehearsal root):
+
+  ```hcl
+  backend "s3" {
+    bucket                       = "<per-root bucket from state_buckets>"
+    region                       = "fr-par"
+    key                          = "terraform.tfstate"
+    encrypt                      = true
+    use_lockfile                 = true
+    skip_credentials_validation  = true
+    skip_region_validation       = true
+    skip_requesting_account_id   = true
+    skip_s3_checksum              = true
+    use_path_style                = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+  }
+  ```
+
+**Real rollout (2026-08-19): every domain migrated.** Same procedure, applied
+to every real root in one session: `01-iam/bootstrap/aws`,
+`01-iam/bootstrap/scaleway`, `01-iam/workload/scaleway`, `02-encryption/aws`,
+`03-storage/scaleway`, `04-vpn/wireguard-exit`,
+`04-vpn/wireguard-site-to-site`, `05-secrets/openbao/bootstrap`,
+`05-secrets/openbao/managed`, `06-monitoring/grafana/bootstrap`,
+`06-monitoring/grafana/managed`, `10-cluster/scaleway`, plus this root
+itself. Every `data "terraform_remote_state"` cross-root read (~11 of them)
+was repointed and parametrized too — bucket/key are now variables set in
+`env/*.tfvars`, not hardcoded literals. `10-cluster/local` has no backend of
+its own (local state) but its two cross-root reads (of `03-storage/scaleway`
+and `02-encryption/aws`) were fixed the same way, so it doesn't read a stale
+AWS-side copy.
+
+One pre-existing, unrelated drift was surfaced (not caused) by the
+migration: `03-storage/scaleway`'s `loki`/`tempo` buckets' live
+`expiration.days` is still 30, while the code (since commit
+"fix(storage): drop Loki + Tempo bucket retention to 1 day") says 1 — that
+commit was never actually applied. Left alone; not this migration's job to
+fix.
+
+**Known follow-up, not yet done**: `.github/actions/terraform/action.yml`
+still only assumes an AWS role for backend state R/W. Every migrated root's
+GitHub Actions workflow needs that updated to pass Scaleway credentials via
+`-backend-config` instead — locally this was done per-command with an
+explicit `-backend-config=<gitignored file>`, keeping ambient
+`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` free for roots with a real
+`provider "aws"` block (`02-encryption/aws`, `01-iam/bootstrap/aws`) — those
+two need real AWS credentials for their own resources regardless of where
+their backend lives, and would collide with Scaleway backend credentials in
+the same env vars.
+
+**The rehearsal's bucket is intentionally still here.** `state_buckets["scratch"]`
+below, and the live `id-terraform-state-99-scratch-migration-test` bucket it
+provisions, are left in place on purpose — `prevent_destroy` included, not to
+be flipped off or worked around. Its cleanup is a manual admin action, on the
+admin's own timeline, once they're satisfied it's no longer needed. Do not
+remove the entry or the bucket without being explicitly asked to.
+
+## Per-bucket identities (2026-08-19)
+
+Originally this root created ONE shared `terraform-state-access` identity
+for every bucket (Scaleway IAM can't scope below project level anyway, so a
+shared identity seemed harmless). Redesigned to reuse
+`modules/scaleway-bucket-with-identity` instead — the same module
+`03-storage/scaleway` already uses — via `for_each` over `var.state_buckets`,
+giving each bucket its **own** dedicated identity by default:
+
+- `create_identity` (module variable, default `true`) toggles whether a
+  given `state_buckets` entry gets its own identity. A root that needs
+  broader Scaleway rights than "CRUD on my own state bucket" gets its
+  identity in `01-iam/` instead and sets this `false` — this module call
+  stays the common case, not the only case.
+- Identity application/policy names and descriptions are **generated**, not
+  supplied — derived from `bucket_name` (itself already globally unique on
+  Scaleway), truncated defensively to Scaleway's 64-rune IAM name limit.
+  Unique-by-construction, no random suffix needed, and traceable back to
+  its bucket at a glance (e.g. `id-terraform-state-03-storage-scaleway-access`).
+- The module itself gained two changes to support this: `expiration_enabled`
+  (default `true`, matching its prior behavior — state buckets set it
+  `false` since their current-version object must never expire) and
+  `create_identity` with a `moved` block (`modules/scaleway-bucket-with-identity/moves.tf`)
+  so adding `count` to the identity submodule didn't force
+  `03-storage/scaleway`'s existing live identities to destroy/recreate.
+
+**Incident during the switchover**: destroying the old shared identity and
+creating the 14 new ones in the same `apply` briefly cut off this root's
+*own* backend authentication mid-apply (it was using the shared identity's
+key via `-backend-config`) — `terraform` lost its S3 credentials partway
+through, leaving one policy resource uncreated and the state lock stuck.
+Recovered by re-`init`-ing with the `scw` CLI's own (human/admin) API key via
+`-backend-config` to regain read/write, `force-unlock`-ing the stale lock,
+then re-`apply`-ing to finish. Lesson: a root's own backend and any identity
+*it itself* provisions are circular if the backend depends on that identity
+— fine for a one-time redesign like this, but don't wire ongoing CI through
+a root's own self-provisioned identity for its own backend without a
+recovery path (the `scw` CLI's admin key filled that role here).
+
+After the swap, every already-migrated root's **local** cached backend
+credentials (each `.terraform/terraform.tfstate` pointer, populated at
+`init -backend-config` time) still pointed at the now-destroyed shared key —
+each was re-`init -reconfigure`d with its own new dedicated identity's
+key/secret (fetched from this root's `access_keys`/`secret_keys` outputs) to
+restore local operability. Nothing CI-facing was affected (the composite
+action doesn't use any of this yet — see the follow-up above).
+
+## Cross-root reads need no manual credential setup
+
+Every `data "terraform_remote_state"` reading a Scaleway-hosted bucket (see
+"Real rollout" above — `10-cluster/local`, `10-cluster/scaleway`,
+`05-secrets/openbao/managed`, `06-monitoring/grafana/bootstrap`,
+`06-monitoring/grafana/managed`) authenticates via a `data "external"`
+block that shells out to `scw config get access-key`/`secret-key` — the
+*exact same* credentials `provider "scaleway" {}` already uses implicitly
+everywhere in this repo. An admin who already has `scw` configured (already
+a repo-wide prerequisite) needs zero extra setup: no env var to export, no
+narrow Terraform-managed identity to fetch and paste in. This deliberately
+avoids requiring `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` set ambiently —
+first tried, then dropped: it worked, but meant fetching one specific
+bucket's dedicated identity key by hand every session, real unnecessary
+friction for someone who's already a full Scaleway admin on their own
+machine. Confirmed working with zero ambient credentials set (2026-08-19).
+
+## The contract
+
+Same four requirements as `00-foundation/aws`'s README (durable+versioned
+store, concurrent-write protection, one narrowly-scoped CI identity, must be
+runnable locally by an admin) — see that README for the full text. This root
+satisfies them the same way, Scaleway-native:
+
+1. `scaleway_object_bucket` per `var.state_buckets` entry, versioning on,
+   SSE-AES256, `prevent_destroy`, and a lifecycle rule that expires only
+   **noncurrent** versions — the current state object is never expired.
+2. `use_lockfile = true` on every consuming root's backend block — confirmed
+   working against Scaleway (see rehearsal findings above).
+3. One Scaleway IAM application + static API key **per bucket**, by default
+   (`modules/scaleway-bucket-with-identity`, see "Per-bucket identities"
+   above) — keyless OIDC isn't available (Scaleway IAM isn't an OIDC relying
+   party, see `01-iam/bootstrap/scaleway/README.md`). Project-scoped Object
+   Storage R/W, same documented limitation as above (a project-level grant,
+   not true per-bucket isolation — this repo's IAM ceiling on Scaleway, not
+   an oversight here).
+4. Applied locally by an admin, same as `00-foundation/aws` and every
+   Scaleway root today (`provider "scaleway" {}` — creds/project from the
+   `scw` CLI config).

--- a/00-foundation/scaleway/env/00-remote-state-backend.tfvars
+++ b/00-foundation/scaleway/env/00-remote-state-backend.tfvars
@@ -1,0 +1,56 @@
+project_id                         = "6283c05b-a4c7-4f83-a75f-83adad236d54"
+region                             = "fr-par"
+noncurrent_version_expiration_days = 10
+
+# Rehearsal bucket for the now-deleted 99-scratch/migration-test root — left
+# in place intentionally (prevent_destroy included), cleanup is a manual
+# admin action on their own timeline. Do not remove or touch it.
+state_buckets = {
+  scratch = {
+    bucket_name = "id-terraform-state-99-scratch-migration-test"
+  }
+
+  # This root's own state (bootstrap: created while backend still points at
+  # the AWS bucket, then repointed here — same pattern 00-foundation/aws used
+  # for itself).
+  foundation_scaleway = {
+    bucket_name = "id-terraform-state-00-foundation-scaleway"
+  }
+
+  iam_bootstrap_aws = {
+    bucket_name = "id-terraform-state-01-iam-bootstrap-aws"
+  }
+  iam_bootstrap_scaleway = {
+    bucket_name = "id-terraform-state-01-iam-bootstrap-scaleway"
+  }
+  iam_workload_scaleway = {
+    bucket_name = "id-terraform-state-01-iam-workload-scaleway"
+  }
+  encryption_aws = {
+    bucket_name = "id-terraform-state-02-encryption-aws"
+  }
+  storage_scaleway = {
+    bucket_name = "id-terraform-state-03-storage-scaleway"
+  }
+  vpn_wireguard_exit = {
+    bucket_name = "id-terraform-state-04-vpn-wireguard-exit"
+  }
+  vpn_wireguard_site_to_site = {
+    bucket_name = "id-terraform-state-04-vpn-wireguard-site-to-site"
+  }
+  secrets_openbao_bootstrap = {
+    bucket_name = "id-terraform-state-05-secrets-openbao-bootstrap"
+  }
+  secrets_openbao_managed = {
+    bucket_name = "id-terraform-state-05-secrets-openbao-managed"
+  }
+  monitoring_grafana_bootstrap = {
+    bucket_name = "id-terraform-state-06-monitoring-grafana-bootstrap"
+  }
+  monitoring_grafana_managed = {
+    bucket_name = "id-terraform-state-06-monitoring-grafana-managed"
+  }
+  cluster_scaleway = {
+    bucket_name = "id-terraform-state-10-cluster-scaleway"
+  }
+}

--- a/00-foundation/scaleway/main.tf
+++ b/00-foundation/scaleway/main.tf
@@ -1,0 +1,36 @@
+# One dedicated Object Storage bucket per consuming root module — see
+# README.md ("Why per-root buckets, not one shared bucket") for why this
+# isn't a single shared bucket the way 00-foundation/aws is. By default, each
+# bucket also gets its OWN least-privilege identity (create_identity = true,
+# the module's default) — a basic CRUD-on-this-bucket-only role is exactly
+# what every root's own backend needs, at minimum. A root that needs broader
+# Scaleway rights than that gets its own identity in 01-iam/ instead
+# (create_identity = false here, so this module doesn't create a redundant
+# one) — see var.state_buckets.
+#
+# expiration_enabled = false: unlike the module's usual tool-bucket use case
+# (03-storage/scaleway), a state bucket's current-version object must NEVER
+# expire regardless of age — only noncurrent_version_expiry_days applies.
+# Mirrors 00-foundation/aws's own bucket for the same reason.
+module "state_buckets" {
+  source   = "../../modules/scaleway-bucket-with-identity"
+  for_each = var.state_buckets
+
+  bucket_name       = each.value.bucket_name
+  region            = coalesce(each.value.region, var.region)
+  lifecycle_rule_id = "expire-noncurrent-state-versions"
+
+  versioning_enabled             = true
+  expiration_enabled             = false
+  noncurrent_version_expiry_days = coalesce(each.value.noncurrent_version_expiration_days, var.noncurrent_version_expiration_days)
+  cold_storage_enabled           = false
+
+  project_id      = var.project_id
+  create_identity = coalesce(each.value.create_identity, true)
+
+  # identity_application_name / identity_policy_name / descriptions /
+  # api_key_description left unset on purpose — the module generates clean,
+  # unique-by-construction names from bucket_name (itself already globally
+  # unique). identity_permission_set_names left at the module default too
+  # (object R/W/delete + bucket read — exactly what a backend needs).
+}

--- a/00-foundation/scaleway/moves.tf
+++ b/00-foundation/scaleway/moves.tf
@@ -1,0 +1,148 @@
+# This root's buckets used to be declared directly here (scaleway_object_bucket.tfstate[...]
+# + scaleway_object_bucket_server_side_encryption_configuration.tfstate[...]), with one shared
+# identity for all of them. Moved into modules/scaleway-bucket-with-identity (one dedicated
+# identity PER bucket by default) without touching any bucket's real data — these moved
+# blocks just tell Terraform the buckets are the same objects, relocated in configuration.
+# The old shared module.terraform_state_access_identity has no moved block: it's genuinely
+# retired, replaced by the per-bucket identities below.
+
+moved {
+  from = scaleway_object_bucket.tfstate["scratch"]
+  to   = module.state_buckets["scratch"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["scratch"]
+  to   = module.state_buckets["scratch"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["foundation_scaleway"]
+  to   = module.state_buckets["foundation_scaleway"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["foundation_scaleway"]
+  to   = module.state_buckets["foundation_scaleway"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["iam_bootstrap_aws"]
+  to   = module.state_buckets["iam_bootstrap_aws"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["iam_bootstrap_aws"]
+  to   = module.state_buckets["iam_bootstrap_aws"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["iam_bootstrap_scaleway"]
+  to   = module.state_buckets["iam_bootstrap_scaleway"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["iam_bootstrap_scaleway"]
+  to   = module.state_buckets["iam_bootstrap_scaleway"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["iam_workload_scaleway"]
+  to   = module.state_buckets["iam_workload_scaleway"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["iam_workload_scaleway"]
+  to   = module.state_buckets["iam_workload_scaleway"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["encryption_aws"]
+  to   = module.state_buckets["encryption_aws"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["encryption_aws"]
+  to   = module.state_buckets["encryption_aws"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["storage_scaleway"]
+  to   = module.state_buckets["storage_scaleway"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["storage_scaleway"]
+  to   = module.state_buckets["storage_scaleway"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["vpn_wireguard_exit"]
+  to   = module.state_buckets["vpn_wireguard_exit"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["vpn_wireguard_exit"]
+  to   = module.state_buckets["vpn_wireguard_exit"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["vpn_wireguard_site_to_site"]
+  to   = module.state_buckets["vpn_wireguard_site_to_site"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["vpn_wireguard_site_to_site"]
+  to   = module.state_buckets["vpn_wireguard_site_to_site"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["secrets_openbao_bootstrap"]
+  to   = module.state_buckets["secrets_openbao_bootstrap"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["secrets_openbao_bootstrap"]
+  to   = module.state_buckets["secrets_openbao_bootstrap"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["secrets_openbao_managed"]
+  to   = module.state_buckets["secrets_openbao_managed"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["secrets_openbao_managed"]
+  to   = module.state_buckets["secrets_openbao_managed"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["monitoring_grafana_bootstrap"]
+  to   = module.state_buckets["monitoring_grafana_bootstrap"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["monitoring_grafana_bootstrap"]
+  to   = module.state_buckets["monitoring_grafana_bootstrap"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["monitoring_grafana_managed"]
+  to   = module.state_buckets["monitoring_grafana_managed"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["monitoring_grafana_managed"]
+  to   = module.state_buckets["monitoring_grafana_managed"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+
+moved {
+  from = scaleway_object_bucket.tfstate["cluster_scaleway"]
+  to   = module.state_buckets["cluster_scaleway"].scaleway_object_bucket.this
+}
+
+moved {
+  from = scaleway_object_bucket_server_side_encryption_configuration.tfstate["cluster_scaleway"]
+  to   = module.state_buckets["cluster_scaleway"].scaleway_object_bucket_server_side_encryption_configuration.this
+}
+

--- a/00-foundation/scaleway/outputs.tf
+++ b/00-foundation/scaleway/outputs.tf
@@ -1,0 +1,20 @@
+output "bucket_names" {
+  description = "Map of root-module slug => provisioned bucket name."
+  value       = { for k, m in module.state_buckets : k => m.bucket_name }
+}
+
+output "bucket_endpoints" {
+  description = "Map of root-module slug => S3-compatible endpoint URL (path-style: https://s3.<region>.scw.cloud/<bucket>)."
+  value       = { for k, m in module.state_buckets : k => m.bucket_endpoint }
+}
+
+output "access_keys" {
+  description = "Map of root-module slug => public access key for its dedicated identity (null where create_identity = false). Consuming roots' backend config needs this (and the matching secret key) via -backend-config, not ambient AWS_* env vars — see README.md."
+  value       = { for k, m in module.state_buckets : k => m.access_key }
+}
+
+output "secret_keys" {
+  description = "Map of root-module slug => secret access key for its dedicated identity (null where create_identity = false)."
+  sensitive   = true
+  value       = { for k, m in module.state_buckets : k => m.secret_key }
+}

--- a/00-foundation/scaleway/variables.tf
+++ b/00-foundation/scaleway/variables.tf
@@ -1,0 +1,33 @@
+# One entry per consuming root module needing a Scaleway-hosted Terraform
+# state bucket. Add a future root's bucket by adding a map entry — no new
+# resources needed (see README.md for why one bucket per root, not shared).
+variable "state_buckets" {
+  description = "Map of root-module slug => its dedicated Terraform state bucket config."
+  type = map(object({
+    bucket_name                        = string
+    region                             = optional(string)
+    noncurrent_version_expiration_days = optional(number)
+    # Whether this bucket gets its own dedicated identity (module default:
+    # true — a basic CRUD-on-this-bucket-only role is what every root needs
+    # at minimum). Set false for a root that already has, or will get, a
+    # broader identity of its own in 01-iam/ instead.
+    create_identity = optional(bool, true)
+  }))
+}
+
+variable "region" {
+  description = "Default Scaleway region for buckets that don't override it per entry."
+  type        = string
+  default     = "fr-par"
+}
+
+variable "noncurrent_version_expiration_days" {
+  description = "Default days after which NONCURRENT (superseded) state versions expire, for buckets that don't override it per entry. The current version is never expired."
+  type        = number
+  default     = 10
+}
+
+variable "project_id" {
+  description = "Scaleway project ID for bucket and IAM resource scoping."
+  type        = string
+}

--- a/00-foundation/scaleway/version.tf
+++ b/00-foundation/scaleway/version.tf
@@ -1,13 +1,13 @@
 terraform {
-  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
-  # state_buckets["iam_bootstrap_scaleway"]).
+  # Bootstrapped: created while this root's own state still lived in the AWS
+  # bucket, then repointed here and migrated with `terraform init
+  # -migrate-state` — the same one-time chicken-and-egg pattern
+  # 00-foundation/aws used for itself. See README.md for the confirmed
+  # backend config findings (path style, checksum, credential wiring).
   backend "s3" {
-    bucket = "id-terraform-state-01-iam-bootstrap-scaleway"
-    region = "fr-par"
-    # Prefix kept as "github-ci" (≠ this root's path 01-iam/bootstrap/scaleway/)
-    # on purpose: the state key is decoupled from the directory, so the repo
-    # restructure was a pure move with zero state migration.
-    workspace_key_prefix        = "github-ci"
+    bucket                      = "id-terraform-state-00-foundation-scaleway"
+    region                      = "fr-par"
+    workspace_key_prefix        = "state-backend-scaleway"
     key                         = "terraform.tfstate"
     encrypt                     = true
     use_lockfile                = true
@@ -33,5 +33,6 @@ terraform {
   }
 }
 
-# Creds, region and project_id come from the scw CLI config (like the other roots).
+# Creds, region and project_id come from the scw CLI config (like the other
+# Scaleway roots).
 provider "scaleway" {}

--- a/01-iam/bootstrap/aws/env/01-iam-aws.tfvars
+++ b/01-iam/bootstrap/aws/env/01-iam-aws.tfvars
@@ -1,1 +1,8 @@
 region = "eu-west-3"
+
+# 00-foundation/aws never migrates off AWS — see main.tf's data source
+# comment — so these stay constant. Explicit here (not just the variables.tf
+# default) so the cross-root target is visible as config, not hidden in code.
+remote_state_aws_bucket = "id-terraform-state20260612164136440800000001"
+remote_state_aws_region = "eu-west-3"
+remote_state_aws_key    = "state-backend/00-remote-state-backend/terraform.tfstate"

--- a/01-iam/bootstrap/aws/main.tf
+++ b/01-iam/bootstrap/aws/main.tf
@@ -14,13 +14,17 @@ data "aws_partition" "current" {}
 
 # 00-foundation/aws's own state — read to attach the SAME state-bucket
 # policy its terraform-state-access role uses, rather than duplicating the
-# policy document or hardcoding its ARN.
+# policy document or hardcoding its ARN. 00-foundation/aws never migrates off
+# the AWS bucket (it IS the AWS bucket — see its own README), so this is the
+# one cross-root reference in the repo that stays AWS-hosted permanently;
+# still parametrized like every other one, so the target is visible as
+# config in env/, not buried in code.
 data "terraform_remote_state" "remote_state_aws" {
   backend = "s3"
   config = {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
-    key    = "state-backend/00-remote-state-backend/terraform.tfstate"
+    bucket = var.remote_state_aws_bucket
+    region = var.remote_state_aws_region
+    key    = var.remote_state_aws_key
   }
 }
 

--- a/01-iam/bootstrap/aws/variables.tf
+++ b/01-iam/bootstrap/aws/variables.tf
@@ -15,3 +15,27 @@ variable "github_repo" {
   type        = string
   default     = "infrastructure"
 }
+
+# ── 00-foundation/aws remote state (cross-root read) ─────────────────────────
+# 00-foundation/aws never migrates off AWS — see main.tf's data source
+# comment — so these values are expected to stay constant. Parametrized
+# anyway for consistency with every other cross-root state reference in the
+# repo, and so the target is visible as config here, not hardcoded in main.tf.
+
+variable "remote_state_aws_bucket" {
+  description = "S3 bucket holding 00-foundation/aws's own remote state."
+  type        = string
+  default     = "id-terraform-state20260612164136440800000001"
+}
+
+variable "remote_state_aws_region" {
+  description = "AWS region of remote_state_aws_bucket."
+  type        = string
+  default     = "eu-west-3"
+}
+
+variable "remote_state_aws_key" {
+  description = "Object key for 00-foundation/aws's state within remote_state_aws_bucket."
+  type        = string
+  default     = "state-backend/00-remote-state-backend/terraform.tfstate"
+}

--- a/01-iam/bootstrap/aws/version.tf
+++ b/01-iam/bootstrap/aws/version.tf
@@ -1,11 +1,25 @@
 terraform {
+  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
+  # state_buckets["iam_bootstrap_aws"]) — independent of the real AWS
+  # credentials `provider "aws"` below uses to manage actual AWS resources.
+  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
+  # state_buckets["iam_bootstrap_aws"]) — independent of the real AWS
+  # credentials `provider "aws"` below uses to manage actual AWS resources.
   backend "s3" {
-    bucket               = "id-terraform-state20260612164136440800000001"
-    region               = "eu-west-3"
-    workspace_key_prefix = "01-iam/bootstrap/aws"
-    key                  = "terraform.tfstate"
-    encrypt              = true
-    use_lockfile         = true
+    bucket                      = "id-terraform-state-01-iam-bootstrap-aws"
+    region                      = "fr-par"
+    workspace_key_prefix        = "01-iam/bootstrap/aws"
+    key                         = "terraform.tfstate"
+    encrypt                     = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
   }
 
   required_providers {

--- a/01-iam/bootstrap/scaleway/.terraform.lock.hcl
+++ b/01-iam/bootstrap/scaleway/.terraform.lock.hcl
@@ -1,29 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version = "6.57.1"
-  hashes = [
-    "h1:Mz2BVjntgeXCYLdhPCpgTBvGNPmxJBJxqq5M4r27Hc8=",
-    "zh:2d29e22480a81c21fb3f2fd52f9bd3ca4a82c37f3bb1b1036e881e42cddc75a1",
-    "zh:33aeb08e9973199b30f8a8e48a58dc67cfb6e32879f7a1c05c521899fe718f53",
-    "zh:37b7f977a7e7d45ad11d42958bc264873fb34573eee925915038ea05607abc9e",
-    "zh:41ebdcf4bcd073a01d58505a5f5118b85668de357d2d9f266926923e817a1842",
-    "zh:43093dfc3559c2c0467c92f48b29ae0221d52e912fce03dd77abd90806fdcc7d",
-    "zh:63b4252933e828d3590c0c64b827ec0f8955aa52df719fe67f45a846111fccc4",
-    "zh:7473b036e9f8167c7a09e4865de95d07922eae6a612b94e819d44c87ba5298de",
-    "zh:783c73e66bf50a74983803e1ec6d6237bae2891f9d4fd4824cfd5350121552ae",
-    "zh:83681e1d8d002048b76d7144cb96c8c8501dc973d1fee41b7579a46ad9eb04c2",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b08b4168d4e2a81badbbe65d95f692ed3292c2b71cd00b9889a3bb7cf54c1188",
-    "zh:b4320ca25f4f67beebcbd6563ece2e490bd9dcb0a7e59b5d7a437ddaf53768ed",
-    "zh:d7f99254d6e05bac3dffae9b437c47cd807b4e66d941e56364be0a28ead418bd",
-    "zh:e433e91689758a341c91840cc7b5d3a3c5089004766d20659d57199b88ad8a5f",
-    "zh:e4c5a9b0f96a5fe2b5ed5592d4c2ac33240cf5308bcb14e52d6f2e0eb183a014",
-    "zh:fc4b554ae98e40e3ab6878ec9501ba2b05213d30668ee357d48b207993ffbe03",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/time" {
   version     = "0.14.0"
   constraints = "~> 0.12"

--- a/01-iam/workload/scaleway/.terraform.lock.hcl
+++ b/01-iam/workload/scaleway/.terraform.lock.hcl
@@ -1,29 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version = "6.57.1"
-  hashes = [
-    "h1:Mz2BVjntgeXCYLdhPCpgTBvGNPmxJBJxqq5M4r27Hc8=",
-    "zh:2d29e22480a81c21fb3f2fd52f9bd3ca4a82c37f3bb1b1036e881e42cddc75a1",
-    "zh:33aeb08e9973199b30f8a8e48a58dc67cfb6e32879f7a1c05c521899fe718f53",
-    "zh:37b7f977a7e7d45ad11d42958bc264873fb34573eee925915038ea05607abc9e",
-    "zh:41ebdcf4bcd073a01d58505a5f5118b85668de357d2d9f266926923e817a1842",
-    "zh:43093dfc3559c2c0467c92f48b29ae0221d52e912fce03dd77abd90806fdcc7d",
-    "zh:63b4252933e828d3590c0c64b827ec0f8955aa52df719fe67f45a846111fccc4",
-    "zh:7473b036e9f8167c7a09e4865de95d07922eae6a612b94e819d44c87ba5298de",
-    "zh:783c73e66bf50a74983803e1ec6d6237bae2891f9d4fd4824cfd5350121552ae",
-    "zh:83681e1d8d002048b76d7144cb96c8c8501dc973d1fee41b7579a46ad9eb04c2",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b08b4168d4e2a81badbbe65d95f692ed3292c2b71cd00b9889a3bb7cf54c1188",
-    "zh:b4320ca25f4f67beebcbd6563ece2e490bd9dcb0a7e59b5d7a437ddaf53768ed",
-    "zh:d7f99254d6e05bac3dffae9b437c47cd807b4e66d941e56364be0a28ead418bd",
-    "zh:e433e91689758a341c91840cc7b5d3a3c5089004766d20659d57199b88ad8a5f",
-    "zh:e4c5a9b0f96a5fe2b5ed5592d4c2ac33240cf5308bcb14e52d6f2e0eb183a014",
-    "zh:fc4b554ae98e40e3ab6878ec9501ba2b05213d30668ee357d48b207993ffbe03",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/time" {
   version     = "0.14.0"
   constraints = "~> 0.12"

--- a/01-iam/workload/scaleway/version.tf
+++ b/01-iam/workload/scaleway/version.tf
@@ -1,16 +1,26 @@
 terraform {
+  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
+  # state_buckets["iam_workload_scaleway"]).
   backend "s3" {
-    bucket               = "id-terraform-state20260612164136440800000001"
-    region               = "eu-west-3"
+    bucket = "id-terraform-state-01-iam-workload-scaleway"
+    region = "fr-par"
     # Prefix kept as "dns/scaleway" (≠ this root's path 01-iam/workload/scaleway/,
     # moved here from 04-dns/scaleway/ since this root owns no DNS resource — it
     # only provisions the external-dns workload identity) on purpose: the state
     # key is decoupled from the directory, so the move was a pure git mv with
     # zero state migration.
-    workspace_key_prefix = "dns/scaleway"
-    key                  = "terraform.tfstate"
-    encrypt              = true
-    use_lockfile         = true
+    workspace_key_prefix        = "dns/scaleway"
+    key                         = "terraform.tfstate"
+    encrypt                     = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
   }
 
   required_providers {

--- a/02-encryption/aws/version.tf
+++ b/02-encryption/aws/version.tf
@@ -1,14 +1,25 @@
 terraform {
+  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
+  # state_buckets["encryption_aws"]) — independent of the real AWS
+  # credentials `provider "aws"` below uses to manage actual AWS resources.
   backend "s3" {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
+    bucket = "id-terraform-state-02-encryption-aws"
+    region = "fr-par"
     # New backend key for this domain — moved out of 03-storage/scaleway
     # (formerly 03-backup/scaleway) via a real cross-backend `terraform state
     # mv`, not a directory rename.
-    workspace_key_prefix = "openbao-unseal/aws"
-    key                  = "terraform.tfstate"
-    encrypt              = true
-    use_lockfile         = true
+    workspace_key_prefix        = "openbao-unseal/aws"
+    key                         = "terraform.tfstate"
+    encrypt                     = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
   }
 
   required_providers {

--- a/03-storage/scaleway/.terraform.lock.hcl
+++ b/03-storage/scaleway/.terraform.lock.hcl
@@ -1,29 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version = "6.57.1"
-  hashes = [
-    "h1:Mz2BVjntgeXCYLdhPCpgTBvGNPmxJBJxqq5M4r27Hc8=",
-    "zh:2d29e22480a81c21fb3f2fd52f9bd3ca4a82c37f3bb1b1036e881e42cddc75a1",
-    "zh:33aeb08e9973199b30f8a8e48a58dc67cfb6e32879f7a1c05c521899fe718f53",
-    "zh:37b7f977a7e7d45ad11d42958bc264873fb34573eee925915038ea05607abc9e",
-    "zh:41ebdcf4bcd073a01d58505a5f5118b85668de357d2d9f266926923e817a1842",
-    "zh:43093dfc3559c2c0467c92f48b29ae0221d52e912fce03dd77abd90806fdcc7d",
-    "zh:63b4252933e828d3590c0c64b827ec0f8955aa52df719fe67f45a846111fccc4",
-    "zh:7473b036e9f8167c7a09e4865de95d07922eae6a612b94e819d44c87ba5298de",
-    "zh:783c73e66bf50a74983803e1ec6d6237bae2891f9d4fd4824cfd5350121552ae",
-    "zh:83681e1d8d002048b76d7144cb96c8c8501dc973d1fee41b7579a46ad9eb04c2",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b08b4168d4e2a81badbbe65d95f692ed3292c2b71cd00b9889a3bb7cf54c1188",
-    "zh:b4320ca25f4f67beebcbd6563ece2e490bd9dcb0a7e59b5d7a437ddaf53768ed",
-    "zh:d7f99254d6e05bac3dffae9b437c47cd807b4e66d941e56364be0a28ead418bd",
-    "zh:e433e91689758a341c91840cc7b5d3a3c5089004766d20659d57199b88ad8a5f",
-    "zh:e4c5a9b0f96a5fe2b5ed5592d4c2ac33240cf5308bcb14e52d6f2e0eb183a014",
-    "zh:fc4b554ae98e40e3ab6878ec9501ba2b05213d30668ee357d48b207993ffbe03",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/time" {
   version     = "0.14.0"
   constraints = "~> 0.12"

--- a/03-storage/scaleway/version.tf
+++ b/03-storage/scaleway/version.tf
@@ -1,11 +1,21 @@
 terraform {
+  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
+  # state_buckets["storage_scaleway"]).
   backend "s3" {
-    bucket               = "id-terraform-state20260612164136440800000001"
-    region               = "eu-west-3"
-    workspace_key_prefix = "backup/scaleway"
-    key                  = "terraform.tfstate"
-    encrypt              = true
-    use_lockfile         = true
+    bucket                      = "id-terraform-state-03-storage-scaleway"
+    region                      = "fr-par"
+    workspace_key_prefix        = "backup/scaleway"
+    key                         = "terraform.tfstate"
+    encrypt                     = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
   }
 
   required_providers {

--- a/04-vpn/wireguard-exit/version.tf
+++ b/04-vpn/wireguard-exit/version.tf
@@ -1,11 +1,21 @@
 terraform {
+  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
+  # state_buckets["vpn_wireguard_exit"]).
   backend "s3" {
-    bucket               = "id-terraform-state20260612164136440800000001"
-    region               = "eu-west-3"
-    workspace_key_prefix = "network/wireguard-exit"
-    key                  = "terraform.tfstate"
-    encrypt              = true
-    use_lockfile         = true
+    bucket                      = "id-terraform-state-04-vpn-wireguard-exit"
+    region                      = "fr-par"
+    workspace_key_prefix        = "network/wireguard-exit"
+    key                         = "terraform.tfstate"
+    encrypt                     = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
   }
 
   required_providers {

--- a/04-vpn/wireguard-site-to-site/version.tf
+++ b/04-vpn/wireguard-site-to-site/version.tf
@@ -1,11 +1,21 @@
 terraform {
+  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
+  # state_buckets["vpn_wireguard_site_to_site"]).
   backend "s3" {
-    bucket               = "id-terraform-state20260612164136440800000001"
-    region               = "eu-west-3"
-    workspace_key_prefix = "network/wireguard"
-    key                  = "terraform.tfstate"
-    encrypt              = true
-    use_lockfile         = true
+    bucket                      = "id-terraform-state-04-vpn-wireguard-site-to-site"
+    region                      = "fr-par"
+    workspace_key_prefix        = "network/wireguard"
+    key                         = "terraform.tfstate"
+    encrypt                     = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
   }
 
   required_providers {

--- a/05-secrets/openbao/bootstrap/.terraform.lock.hcl
+++ b/05-secrets/openbao/bootstrap/.terraform.lock.hcl
@@ -1,34 +1,12 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version = "6.56.0"
-  hashes = [
-    "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
-    "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
-    "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
-    "zh:67dca271bef16547ef8ab5a6349f9bce39d91d7c1ae3d8388ada687ca774ba44",
-    "zh:824c812695b14d2fddad5e22339d4520e16d9c875f5d5095f29003f49a6fd124",
-    "zh:8372b12e30078d1df8b52e1285fd0d9d35160a7d18c3b0211f55229e5a832fd3",
-    "zh:8922b45ab65e272e8951f70d890444ddb3441170d8fa6f51298f24f20d21943d",
-    "zh:8fc4fb94ac8547717128cbcf296ac0ba0918738c4882029cbba46bd4812eb5e4",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a2efcd0174b79c1dffce48a5984f137ebc6f67d2c2ee966b47210e1faeb05cf2",
-    "zh:a4a50aa269a19c1d664b0dd59ee8047ed8a4a5b449f54733518309feccce1f43",
-    "zh:a830d80316b3c3127c9e0c77b9d4f50702c9d1a884c08973ac50b326d9ac734a",
-    "zh:d7e1b9bb2df3cdde8381ab101a807ae54e72c156d13a6b73dae2b922dca0c9f5",
-    "zh:d87c2a1cfc03b01cf13dff3700898ab990e1817326728824da8499dd0129da72",
-    "zh:fbb1848a597263c66dc6587ec8c3e0586e505e36f99d23752763534f62a3fef7",
-    "zh:fcb54d08eb3c763f01223e12b4eacbd018478e8e67c6b8611940564dfbea3d90",
-    "zh:ff6df70b2b2f75bd9000630f131c02e6bc2b9172cdb2547030f3fc019a3f3bc5",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/vault" {
   version     = "5.10.1"
   constraints = "~> 5.0"
   hashes = [
     "h1:f+4Eh/Bzl1iun3tG3oCol/zsEqAwtFpl1PP59l8DL+k=",
+    "h1:lyFssgWG/91rFC++zoiJQDaqhzWieLL64bIF6+53Hq4=",
     "zh:0de49889bc7cfb66f9004651252e4c38acb0c927335ce0cbe1ee59a576030a44",
     "zh:1875cbcbac4bf19f2e9f9bd6f7a4589419f65969676c879b5c80ca4823818011",
     "zh:32f51e4eae2157a3c56ff40cd72f218776a9a8cc2151a6d78a36078c87243ac7",

--- a/05-secrets/openbao/bootstrap/version.tf
+++ b/05-secrets/openbao/bootstrap/version.tf
@@ -1,11 +1,21 @@
 terraform {
+  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
+  # state_buckets["secrets_openbao_bootstrap"]).
   backend "s3" {
-    bucket               = "id-terraform-state20260612164136440800000001"
-    region               = "eu-west-3"
-    workspace_key_prefix = "secrets/bootstrap/openbao"
-    key                  = "terraform.tfstate"
-    encrypt              = true
-    use_lockfile         = true
+    bucket                      = "id-terraform-state-05-secrets-openbao-bootstrap"
+    region                      = "fr-par"
+    workspace_key_prefix        = "secrets/bootstrap/openbao"
+    key                         = "terraform.tfstate"
+    encrypt                     = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
   }
 
   required_providers {

--- a/05-secrets/openbao/managed/.terraform.lock.hcl
+++ b/05-secrets/openbao/managed/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.4.1"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:VpNKqlWiwV5e6jgspQ0OqqC1hHZ6uiOzM7/irRAmj4o=",
+    "h1:pNEBlwrLd7hJ+bBZwxVM3jfV9HmsueDD83xyXAFEQR8=",
+    "zh:4729bb3f5a6162c6662e51ddd6fce39206632c98109db9969fba65fd063da1af",
+    "zh:4be9471fcf2dfc72bb70a91f526e3c6e35f5f9f656b2ee6eebcb8acdeeecfb48",
+    "zh:526625afb495fb01e3cf48cc4bd974340ac0b7c6fe5f1a6daac5f8aed3836f9e",
+    "zh:6c1287366f8841288108cda7801092940c0dc80a5bad28bf012825c921bcc5ef",
+    "zh:707b2aa4f93a0d8682e81890bfaa5c7199f3e6d2fdbafbf4f89996cb7f0e291e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fb382f0b266e98d5c78a39426b063aefffce566f12b19fd722a93e8127108af",
+    "zh:89092c1ab478457266ca4c064c4ee77225a2de01a37a1a15c542f978e3db8a32",
+    "zh:b066a49f3fe3ff49427f2b93b919c7c34ed01236fd594283cb1baf1521566464",
+    "zh:d5d66dd91f7a58e397e10360f45a92a1a3a66388a67036e30b426b873f58667c",
+    "zh:df2479f69e15843dc1671127018b7fcc1a0ddc8f93afb61e730c1ad5c3e365e8",
+    "zh:f1881dec0cd543bc351299a5bc08743716b7eed1043a43da4347fd42b1cc0563",
+    "zh:fe03df7ead78b43137ef9d805ae638daa86516345d3c44e81a2944d3d256e587",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.9.0"
   constraints = "~> 3.6"

--- a/05-secrets/openbao/managed/env/05-secrets-openbao-secrets.tfvars
+++ b/05-secrets/openbao/managed/env/05-secrets-openbao-secrets.tfvars
@@ -1,4 +1,20 @@
-# No non-sensitive overrides needed — everything this root takes (AppRole
-# creds, oidc_client_secret) is sensitive and lives in a gitignored
-# local.auto.tfvars instead. This file exists to name the terraform workspace
-# ("05-secrets-openbao-secrets"), per repo convention.
+# Everything sensitive (AppRole creds, oidc_client_secret) is in a gitignored
+# local.auto.tfvars instead. This file names the terraform workspace
+# ("05-secrets-openbao-secrets") and carries the non-secret cross-root state
+# bucket/key config below — see 00-foundation/scaleway/env/00-remote-state-backend.tfvars
+# for the full bucket list.
+
+dns_scaleway_state_bucket = "id-terraform-state-01-iam-workload-scaleway"
+dns_scaleway_state_key    = "dns/scaleway/04-dns-scaleway/terraform.tfstate"
+
+backup_scaleway_state_bucket = "id-terraform-state-03-storage-scaleway"
+backup_scaleway_state_key    = "backup/scaleway/03-backup-dev-bucket/terraform.tfstate"
+
+wireguard_state_bucket = "id-terraform-state-04-vpn-wireguard-site-to-site"
+wireguard_state_key    = "network/wireguard/04-network-wireguard/terraform.tfstate"
+
+wireguard_exit_state_bucket = "id-terraform-state-04-vpn-wireguard-exit"
+wireguard_exit_state_key    = "network/wireguard-exit/04-network-wireguard-exit/terraform.tfstate"
+
+openbao_bootstrap_state_bucket = "id-terraform-state-05-secrets-openbao-bootstrap"
+openbao_bootstrap_state_key    = "secrets/bootstrap/openbao/05-secrets-openbao/terraform.tfstate"

--- a/05-secrets/openbao/managed/main.tf
+++ b/05-secrets/openbao/managed/main.tf
@@ -1,3 +1,37 @@
+# Credentials for the cross-root Scaleway state reads below: read straight
+# from the scw CLI's own config (the same credentials `provider "scaleway"
+# {}` already uses implicitly everywhere else) instead of requiring
+# AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY set ambiently. Terraform's s3
+# backend/data source has no notion of the scw CLI's own config format —
+# this bridges the two credential systems automatically, so any admin who
+# already has `scw` configured (a repo-wide prerequisite already) needs zero
+# extra setup.
+data "external" "scw_credentials" {
+  program = ["sh", "-c", "jq -n --arg ak \"$(scw config get access-key)\" --arg sk \"$(scw config get secret-key)\" '{access_key:$ak, secret_key:$sk}'"]
+}
+
+# Shared technical attributes for every cross-root Scaleway state read on
+# this page — not "config" in the meaningful sense (they never vary), just
+# the Scaleway S3-compatible endpoint mechanics repeated per data source
+# otherwise. The actual config — which bucket/key, i.e. which root's state —
+# is parametrized via variables.tf + env/, visible there instead of buried
+# here.
+locals {
+  scaleway_state_backend = {
+    region                      = "fr-par"
+    access_key                  = data.external.scw_credentials.result.access_key
+    secret_key                  = data.external.scw_credentials.result.secret_key
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+  }
+}
+
 # --- KV v2: application/service secret data. Mounted manually 2026-07-20 (see
 # gitops repo's PLAN-secrets-sync-github.md) — brought under Terraform here
 # without changing its shape. The secret content itself is managed further
@@ -209,20 +243,18 @@ resource "vault_policy" "admin" {
 
 data "terraform_remote_state" "dns_scaleway" {
   backend = "s3"
-  config = {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
-    key    = "dns/scaleway/04-dns-scaleway/terraform.tfstate"
-  }
+  config = merge(local.scaleway_state_backend, {
+    bucket = var.dns_scaleway_state_bucket
+    key    = var.dns_scaleway_state_key
+  })
 }
 
 data "terraform_remote_state" "backup_scaleway" {
   backend = "s3"
-  config = {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
-    key    = "backup/scaleway/03-backup-dev-bucket/terraform.tfstate"
-  }
+  config = merge(local.scaleway_state_backend, {
+    bucket = var.backup_scaleway_state_bucket
+    key    = var.backup_scaleway_state_key
+  })
 }
 
 # 04-vpn/wireguard-site-to-site's own state — read directly instead of a
@@ -235,11 +267,10 @@ data "terraform_remote_state" "backup_scaleway" {
 # move if that domain gets renamed again.
 data "terraform_remote_state" "wireguard" {
   backend = "s3"
-  config = {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
-    key    = "network/wireguard/04-network-wireguard/terraform.tfstate"
-  }
+  config = merge(local.scaleway_state_backend, {
+    bucket = var.wireguard_state_bucket
+    key    = var.wireguard_state_key
+  })
 }
 
 # 04-vpn/wireguard-exit's own state — the second, unrelated WireGuard
@@ -247,11 +278,10 @@ data "terraform_remote_state" "wireguard" {
 # Same read-directly-via-remote-state pattern.
 data "terraform_remote_state" "wireguard_exit" {
   backend = "s3"
-  config = {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
-    key    = "network/wireguard-exit/04-network-wireguard-exit/terraform.tfstate"
-  }
+  config = merge(local.scaleway_state_backend, {
+    bucket = var.wireguard_exit_state_bucket
+    key    = var.wireguard_exit_state_key
+  })
 }
 
 # --- Arbitrary Dex<->client shared secrets: nothing external constrains

--- a/05-secrets/openbao/managed/variables.tf
+++ b/05-secrets/openbao/managed/variables.tf
@@ -54,3 +54,50 @@ variable "secrets_sync_github" {
   })
   sensitive = true
 }
+
+# ── Cross-root state reads (Scaleway state buckets, see 00-foundation/scaleway) ──
+
+variable "dns_scaleway_state_bucket" {
+  description = "Scaleway bucket holding 01-iam/workload/scaleway's remote state."
+  type        = string
+}
+variable "dns_scaleway_state_key" {
+  description = "Object key for 01-iam/workload/scaleway's state within dns_scaleway_state_bucket."
+  type        = string
+}
+
+variable "backup_scaleway_state_bucket" {
+  description = "Scaleway bucket holding 03-storage/scaleway's remote state."
+  type        = string
+}
+variable "backup_scaleway_state_key" {
+  description = "Object key for 03-storage/scaleway's state within backup_scaleway_state_bucket."
+  type        = string
+}
+
+variable "wireguard_state_bucket" {
+  description = "Scaleway bucket holding 04-vpn/wireguard-site-to-site's remote state."
+  type        = string
+}
+variable "wireguard_state_key" {
+  description = "Object key for 04-vpn/wireguard-site-to-site's state within wireguard_state_bucket."
+  type        = string
+}
+
+variable "wireguard_exit_state_bucket" {
+  description = "Scaleway bucket holding 04-vpn/wireguard-exit's remote state."
+  type        = string
+}
+variable "wireguard_exit_state_key" {
+  description = "Object key for 04-vpn/wireguard-exit's state within wireguard_exit_state_bucket."
+  type        = string
+}
+
+variable "openbao_bootstrap_state_bucket" {
+  description = "Scaleway bucket holding 05-secrets/openbao/bootstrap's remote state."
+  type        = string
+}
+variable "openbao_bootstrap_state_key" {
+  description = "Object key for 05-secrets/openbao/bootstrap's state within openbao_bootstrap_state_bucket."
+  type        = string
+}

--- a/05-secrets/openbao/managed/version.tf
+++ b/05-secrets/openbao/managed/version.tf
@@ -1,11 +1,21 @@
 terraform {
+  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
+  # state_buckets["secrets_openbao_managed"]).
   backend "s3" {
-    bucket               = "id-terraform-state20260612164136440800000001"
-    region               = "eu-west-3"
-    workspace_key_prefix = "secrets/managed/openbao"
-    key                  = "terraform.tfstate"
-    encrypt              = true
-    use_lockfile         = true
+    bucket                      = "id-terraform-state-05-secrets-openbao-managed"
+    region                      = "fr-par"
+    workspace_key_prefix        = "secrets/managed/openbao"
+    key                         = "terraform.tfstate"
+    encrypt                     = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
   }
 
   required_providers {
@@ -16,6 +26,10 @@ terraform {
     random = {
       source  = "hashicorp/random"
       version = "~> 3.6"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.0"
     }
   }
 }
@@ -29,11 +43,10 @@ terraform {
 # off a resource attribute.
 data "terraform_remote_state" "openbao_bootstrap" {
   backend = "s3"
-  config = {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
-    key    = "secrets/bootstrap/openbao/05-secrets-openbao/terraform.tfstate"
-  }
+  config = merge(local.scaleway_state_backend, {
+    bucket = var.openbao_bootstrap_state_bucket
+    key    = var.openbao_bootstrap_state_key
+  })
 }
 
 # Authenticates as the `terraform` AppRole from 05-secrets/openbao/bootstrap —

--- a/06-monitoring/grafana/bootstrap/.terraform.lock.hcl
+++ b/06-monitoring/grafana/bootstrap/.terraform.lock.hcl
@@ -28,3 +28,25 @@ provider "registry.terraform.io/grafana/grafana" {
     "zh:d7a1646c9167c1a464566cb755697b5d212469b91d762cf153cb29c4439d3652",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.4.1"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:VpNKqlWiwV5e6jgspQ0OqqC1hHZ6uiOzM7/irRAmj4o=",
+    "h1:pNEBlwrLd7hJ+bBZwxVM3jfV9HmsueDD83xyXAFEQR8=",
+    "zh:4729bb3f5a6162c6662e51ddd6fce39206632c98109db9969fba65fd063da1af",
+    "zh:4be9471fcf2dfc72bb70a91f526e3c6e35f5f9f656b2ee6eebcb8acdeeecfb48",
+    "zh:526625afb495fb01e3cf48cc4bd974340ac0b7c6fe5f1a6daac5f8aed3836f9e",
+    "zh:6c1287366f8841288108cda7801092940c0dc80a5bad28bf012825c921bcc5ef",
+    "zh:707b2aa4f93a0d8682e81890bfaa5c7199f3e6d2fdbafbf4f89996cb7f0e291e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fb382f0b266e98d5c78a39426b063aefffce566f12b19fd722a93e8127108af",
+    "zh:89092c1ab478457266ca4c064c4ee77225a2de01a37a1a15c542f978e3db8a32",
+    "zh:b066a49f3fe3ff49427f2b93b919c7c34ed01236fd594283cb1baf1521566464",
+    "zh:d5d66dd91f7a58e397e10360f45a92a1a3a66388a67036e30b426b873f58667c",
+    "zh:df2479f69e15843dc1671127018b7fcc1a0ddc8f93afb61e730c1ad5c3e365e8",
+    "zh:f1881dec0cd543bc351299a5bc08743716b7eed1043a43da4347fd42b1cc0563",
+    "zh:fe03df7ead78b43137ef9d805ae638daa86516345d3c44e81a2944d3d256e587",
+  ]
+}

--- a/06-monitoring/grafana/bootstrap/env/06-monitoring-grafana.tfvars
+++ b/06-monitoring/grafana/bootstrap/env/06-monitoring-grafana.tfvars
@@ -1,3 +1,6 @@
-# No overrides needed yet — service_account_token_ttl_days defaults sensibly
-# (see variables.tf). This file exists to name the terraform workspace
-# ("06-monitoring-grafana"), per repo convention.
+# service_account_token_ttl_days defaults sensibly (see variables.tf). This
+# file names the terraform workspace ("06-monitoring-grafana") and carries
+# the non-secret cross-root state bucket/key config below.
+
+openbao_managed_state_bucket = "id-terraform-state-05-secrets-openbao-managed"
+openbao_managed_state_key    = "secrets/managed/openbao/05-secrets-openbao-secrets/terraform.tfstate"

--- a/06-monitoring/grafana/bootstrap/variables.tf
+++ b/06-monitoring/grafana/bootstrap/variables.tf
@@ -7,3 +7,15 @@ variable "service_account_token_ttl_days" {
   type        = number
   default     = 0
 }
+
+# ── Cross-root state reads (Scaleway state buckets, see 00-foundation/scaleway) ──
+
+variable "openbao_managed_state_bucket" {
+  description = "Scaleway bucket holding 05-secrets/openbao/managed's remote state."
+  type        = string
+}
+
+variable "openbao_managed_state_key" {
+  description = "Object key for 05-secrets/openbao/managed's state within openbao_managed_state_bucket."
+  type        = string
+}

--- a/06-monitoring/grafana/bootstrap/version.tf
+++ b/06-monitoring/grafana/bootstrap/version.tf
@@ -1,17 +1,31 @@
 terraform {
+  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
+  # state_buckets["monitoring_grafana_bootstrap"]).
   backend "s3" {
-    bucket               = "id-terraform-state20260612164136440800000001"
-    region               = "eu-west-3"
-    workspace_key_prefix = "monitoring/bootstrap/grafana"
-    key                  = "terraform.tfstate"
-    encrypt              = true
-    use_lockfile         = true
+    bucket                      = "id-terraform-state-06-monitoring-grafana-bootstrap"
+    region                      = "fr-par"
+    workspace_key_prefix        = "monitoring/bootstrap/grafana"
+    key                         = "terraform.tfstate"
+    encrypt                     = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
   }
 
   required_providers {
     grafana = {
       source  = "grafana/grafana"
       version = "~> 4.0"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.0"
     }
   }
 }
@@ -24,13 +38,44 @@ terraform {
 # own actual workspace (confirmed via `terraform workspace show`), distinct
 # from 05-secrets/openbao/bootstrap's "05-secrets-openbao" — don't assume
 # the two roots under openbao/ share one workspace name.
+# Credentials for the cross-root Scaleway state read below: read straight
+# from the scw CLI's own config (the same credentials `provider "scaleway"
+# {}` already uses implicitly everywhere else) instead of requiring
+# AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY set ambiently. Terraform's s3
+# backend/data source has no notion of the scw CLI's own config format —
+# this bridges the two credential systems automatically, so any admin who
+# already has `scw` configured (a repo-wide prerequisite already) needs zero
+# extra setup.
+data "external" "scw_credentials" {
+  program = ["sh", "-c", "jq -n --arg ak \"$(scw config get access-key)\" --arg sk \"$(scw config get secret-key)\" '{access_key:$ak, secret_key:$sk}'"]
+}
+
+locals {
+  # See main.tf-equivalent comment elsewhere in the repo: shared technical
+  # attributes for the cross-root Scaleway state read below, not "config" in
+  # the meaningful sense. The actual target is parametrized via variables.tf
+  # + env/, visible there instead of buried here.
+  scaleway_state_backend = {
+    region                      = "fr-par"
+    access_key                  = data.external.scw_credentials.result.access_key
+    secret_key                  = data.external.scw_credentials.result.secret_key
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+  }
+}
+
 data "terraform_remote_state" "openbao_managed" {
   backend = "s3"
-  config = {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
-    key    = "secrets/managed/openbao/05-secrets-openbao-secrets/terraform.tfstate"
-  }
+  config = merge(local.scaleway_state_backend, {
+    bucket = var.openbao_managed_state_bucket
+    key    = var.openbao_managed_state_key
+  })
 }
 
 # Authenticates as Grafana's own admin via basic auth — the same admin

--- a/06-monitoring/grafana/managed/.terraform.lock.hcl
+++ b/06-monitoring/grafana/managed/.terraform.lock.hcl
@@ -28,3 +28,25 @@ provider "registry.terraform.io/grafana/grafana" {
     "zh:d7a1646c9167c1a464566cb755697b5d212469b91d762cf153cb29c4439d3652",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.4.1"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:VpNKqlWiwV5e6jgspQ0OqqC1hHZ6uiOzM7/irRAmj4o=",
+    "h1:pNEBlwrLd7hJ+bBZwxVM3jfV9HmsueDD83xyXAFEQR8=",
+    "zh:4729bb3f5a6162c6662e51ddd6fce39206632c98109db9969fba65fd063da1af",
+    "zh:4be9471fcf2dfc72bb70a91f526e3c6e35f5f9f656b2ee6eebcb8acdeeecfb48",
+    "zh:526625afb495fb01e3cf48cc4bd974340ac0b7c6fe5f1a6daac5f8aed3836f9e",
+    "zh:6c1287366f8841288108cda7801092940c0dc80a5bad28bf012825c921bcc5ef",
+    "zh:707b2aa4f93a0d8682e81890bfaa5c7199f3e6d2fdbafbf4f89996cb7f0e291e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fb382f0b266e98d5c78a39426b063aefffce566f12b19fd722a93e8127108af",
+    "zh:89092c1ab478457266ca4c064c4ee77225a2de01a37a1a15c542f978e3db8a32",
+    "zh:b066a49f3fe3ff49427f2b93b919c7c34ed01236fd594283cb1baf1521566464",
+    "zh:d5d66dd91f7a58e397e10360f45a92a1a3a66388a67036e30b426b873f58667c",
+    "zh:df2479f69e15843dc1671127018b7fcc1a0ddc8f93afb61e730c1ad5c3e365e8",
+    "zh:f1881dec0cd543bc351299a5bc08743716b7eed1043a43da4347fd42b1cc0563",
+    "zh:fe03df7ead78b43137ef9d805ae638daa86516345d3c44e81a2944d3d256e587",
+  ]
+}

--- a/06-monitoring/grafana/managed/env/06-monitoring-grafana.tfvars
+++ b/06-monitoring/grafana/managed/env/06-monitoring-grafana.tfvars
@@ -1,3 +1,6 @@
-# No overrides needed yet — mcp_service_account_token_ttl_days defaults
-# sensibly (see variables.tf). This file exists to name the terraform
-# workspace ("06-monitoring-grafana"), per repo convention.
+# mcp_service_account_token_ttl_days defaults sensibly (see variables.tf).
+# This file names the terraform workspace ("06-monitoring-grafana") and
+# carries the non-secret cross-root state bucket/key config below.
+
+grafana_bootstrap_state_bucket = "id-terraform-state-06-monitoring-grafana-bootstrap"
+grafana_bootstrap_state_key    = "monitoring/bootstrap/grafana/06-monitoring-grafana/terraform.tfstate"

--- a/06-monitoring/grafana/managed/variables.tf
+++ b/06-monitoring/grafana/managed/variables.tf
@@ -5,3 +5,15 @@ variable "mcp_service_account_token_ttl_days" {
   type        = number
   default     = 0
 }
+
+# ── Cross-root state reads (Scaleway state buckets, see 00-foundation/scaleway) ──
+
+variable "grafana_bootstrap_state_bucket" {
+  description = "Scaleway bucket holding 06-monitoring/grafana/bootstrap's remote state."
+  type        = string
+}
+
+variable "grafana_bootstrap_state_key" {
+  description = "Object key for 06-monitoring/grafana/bootstrap's state within grafana_bootstrap_state_bucket."
+  type        = string
+}

--- a/06-monitoring/grafana/managed/version.tf
+++ b/06-monitoring/grafana/managed/version.tf
@@ -1,17 +1,31 @@
 terraform {
+  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
+  # state_buckets["monitoring_grafana_managed"]).
   backend "s3" {
-    bucket               = "id-terraform-state20260612164136440800000001"
-    region               = "eu-west-3"
-    workspace_key_prefix = "monitoring/managed/grafana"
-    key                  = "terraform.tfstate"
-    encrypt              = true
-    use_lockfile         = true
+    bucket                      = "id-terraform-state-06-monitoring-grafana-managed"
+    region                      = "fr-par"
+    workspace_key_prefix        = "monitoring/managed/grafana"
+    key                         = "terraform.tfstate"
+    encrypt                     = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
   }
 
   required_providers {
     grafana = {
       source  = "grafana/grafana"
       version = "~> 4.0"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.0"
     }
   }
 }
@@ -20,13 +34,44 @@ terraform {
 # account token this root authenticates as. Cross-root remote-state read,
 # not a hand-copied value, same convention as every other cross-root
 # credential in this repo.
+# Credentials for the cross-root Scaleway state read below: read straight
+# from the scw CLI's own config (the same credentials `provider "scaleway"
+# {}` already uses implicitly everywhere else) instead of requiring
+# AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY set ambiently. Terraform's s3
+# backend/data source has no notion of the scw CLI's own config format —
+# this bridges the two credential systems automatically, so any admin who
+# already has `scw` configured (a repo-wide prerequisite already) needs zero
+# extra setup.
+data "external" "scw_credentials" {
+  program = ["sh", "-c", "jq -n --arg ak \"$(scw config get access-key)\" --arg sk \"$(scw config get secret-key)\" '{access_key:$ak, secret_key:$sk}'"]
+}
+
+locals {
+  # See main.tf-equivalent comment elsewhere in the repo: shared technical
+  # attributes for the cross-root Scaleway state read below, not "config" in
+  # the meaningful sense. The actual target is parametrized via variables.tf
+  # + env/, visible there instead of buried here.
+  scaleway_state_backend = {
+    region                      = "fr-par"
+    access_key                  = data.external.scw_credentials.result.access_key
+    secret_key                  = data.external.scw_credentials.result.secret_key
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+  }
+}
+
 data "terraform_remote_state" "grafana_bootstrap" {
   backend = "s3"
-  config = {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
-    key    = "monitoring/bootstrap/grafana/06-monitoring-grafana/terraform.tfstate"
-  }
+  config = merge(local.scaleway_state_backend, {
+    bucket = var.grafana_bootstrap_state_bucket
+    key    = var.grafana_bootstrap_state_key
+  })
 }
 
 # Already a bearer-style API token (grafana_service_account_token.key) — no

--- a/10-cluster/local/.terraform.lock.hcl
+++ b/10-cluster/local/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.4.1"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:VpNKqlWiwV5e6jgspQ0OqqC1hHZ6uiOzM7/irRAmj4o=",
+    "h1:pNEBlwrLd7hJ+bBZwxVM3jfV9HmsueDD83xyXAFEQR8=",
+    "zh:4729bb3f5a6162c6662e51ddd6fce39206632c98109db9969fba65fd063da1af",
+    "zh:4be9471fcf2dfc72bb70a91f526e3c6e35f5f9f656b2ee6eebcb8acdeeecfb48",
+    "zh:526625afb495fb01e3cf48cc4bd974340ac0b7c6fe5f1a6daac5f8aed3836f9e",
+    "zh:6c1287366f8841288108cda7801092940c0dc80a5bad28bf012825c921bcc5ef",
+    "zh:707b2aa4f93a0d8682e81890bfaa5c7199f3e6d2fdbafbf4f89996cb7f0e291e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fb382f0b266e98d5c78a39426b063aefffce566f12b19fd722a93e8127108af",
+    "zh:89092c1ab478457266ca4c064c4ee77225a2de01a37a1a15c542f978e3db8a32",
+    "zh:b066a49f3fe3ff49427f2b93b919c7c34ed01236fd594283cb1baf1521566464",
+    "zh:d5d66dd91f7a58e397e10360f45a92a1a3a66388a67036e30b426b873f58667c",
+    "zh:df2479f69e15843dc1671127018b7fcc1a0ddc8f93afb61e730c1ad5c3e365e8",
+    "zh:f1881dec0cd543bc351299a5bc08743716b7eed1043a43da4347fd42b1cc0563",
+    "zh:fe03df7ead78b43137ef9d805ae638daa86516345d3c44e81a2944d3d256e587",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/helm" {
   version     = "3.2.0"
   constraints = "~> 3.0"

--- a/10-cluster/local/main.tf
+++ b/10-cluster/local/main.tf
@@ -9,27 +9,58 @@ locals {
   argocd_password_hash = var.argocd_admin_password_hash != "" ? var.argocd_admin_password_hash : data.infisical_secrets.this[0].secrets["ArgoCD_admin_encrypted"].value
 }
 
+# Credentials for the cross-root Scaleway state reads below: read straight
+# from the scw CLI's own config (the same credentials `provider "scaleway"
+# {}` already uses implicitly everywhere else) instead of requiring
+# AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY set ambiently. Terraform's s3
+# backend/data source has no notion of the scw CLI's own config format —
+# this bridges the two credential systems automatically, so any admin who
+# already has `scw` configured (a repo-wide prerequisite already) needs zero
+# extra setup.
+data "external" "scw_credentials" {
+  program = ["sh", "-c", "jq -n --arg ak \"$(scw config get access-key)\" --arg sk \"$(scw config get secret-key)\" '{access_key:$ak, secret_key:$sk}'"]
+}
+
+# Shared technical attributes for every cross-root Scaleway state read below
+# — not "config" in the meaningful sense (they never vary), just the
+# Scaleway S3-compatible endpoint mechanics repeated per data source
+# otherwise. The actual config — which bucket/key, i.e. which root's state —
+# is parametrized via variables.tf, visible there instead of buried here.
+locals {
+  scaleway_state_backend = {
+    region                      = "fr-par"
+    access_key                  = data.external.scw_credentials.result.access_key
+    secret_key                  = data.external.scw_credentials.result.secret_key
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+  }
+}
+
 # scaleway-s3-credentials source: 03-storage/scaleway's "backup" bucket + its
 # scoped workload identity. Same remote state key 05-secrets/openbao/managed
 # reads as its own `backup_scaleway` data source.
 data "terraform_remote_state" "backup_scaleway" {
   backend = "s3"
-  config = {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
-    key    = "backup/scaleway/03-backup-dev-bucket/terraform.tfstate"
-  }
+  config = merge(local.scaleway_state_backend, {
+    bucket = var.backup_scaleway_state_bucket
+    key    = var.backup_scaleway_state_key
+  })
 }
 
 # AWS credentials OpenBao reads at startup for KMS auto-unseal (seal "awskms")
 # — source: 02-encryption/aws's KMS key + dedicated IAM user.
 data "terraform_remote_state" "openbao_unseal_aws" {
   backend = "s3"
-  config = {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
-    key    = "openbao-unseal/aws/03-backup-dev-bucket/terraform.tfstate"
-  }
+  config = merge(local.scaleway_state_backend, {
+    bucket = var.openbao_unseal_aws_state_bucket
+    key    = var.openbao_unseal_aws_state_key
+  })
 }
 
 resource "kubernetes_namespace" "openbao" {
@@ -45,9 +76,9 @@ resource "kubernetes_secret" "scaleway_s3_credentials" {
   }
 
   data = {
-    bucket                 = data.terraform_remote_state.backup_scaleway.outputs.bucket_name
-    AWS_ACCESS_KEY_ID      = data.terraform_remote_state.backup_scaleway.outputs.workload_access_key
-    AWS_SECRET_ACCESS_KEY  = data.terraform_remote_state.backup_scaleway.outputs.workload_secret_key
+    bucket                = data.terraform_remote_state.backup_scaleway.outputs.bucket_name
+    AWS_ACCESS_KEY_ID     = data.terraform_remote_state.backup_scaleway.outputs.workload_access_key
+    AWS_SECRET_ACCESS_KEY = data.terraform_remote_state.backup_scaleway.outputs.workload_secret_key
   }
 }
 
@@ -63,7 +94,7 @@ resource "kubernetes_secret" "openbao_unseal_aws" {
   }
 
   data = {
-    AWS_ACCESS_KEY_ID = data.terraform_remote_state.openbao_unseal_aws.outputs.openbao_unseal_access_key_id
+    AWS_ACCESS_KEY_ID     = data.terraform_remote_state.openbao_unseal_aws.outputs.openbao_unseal_access_key_id
     AWS_SECRET_ACCESS_KEY = data.terraform_remote_state.openbao_unseal_aws.outputs.openbao_unseal_secret_access_key
   }
 }

--- a/10-cluster/local/variables.tf
+++ b/10-cluster/local/variables.tf
@@ -17,3 +17,32 @@ variable "argocd_admin_password_hash" {
   # default     = ""
 }
 
+# ── Cross-root state reads (Scaleway state buckets, see 00-foundation/scaleway) ──
+# Defaulted (unlike other roots' env/*.tfvars-required equivalents) since this
+# root's own vars come from a per-developer, gitignored nico.auto.tfvars file
+# — defaults keep it working without every developer having to add these.
+
+variable "backup_scaleway_state_bucket" {
+  description = "Scaleway bucket holding 03-storage/scaleway's remote state."
+  type        = string
+  default     = "id-terraform-state-03-storage-scaleway"
+}
+
+variable "backup_scaleway_state_key" {
+  description = "Object key for 03-storage/scaleway's state within backup_scaleway_state_bucket."
+  type        = string
+  default     = "backup/scaleway/03-backup-dev-bucket/terraform.tfstate"
+}
+
+variable "openbao_unseal_aws_state_bucket" {
+  description = "Scaleway bucket holding 02-encryption/aws's remote state."
+  type        = string
+  default     = "id-terraform-state-02-encryption-aws"
+}
+
+variable "openbao_unseal_aws_state_key" {
+  description = "Object key for 02-encryption/aws's state within openbao_unseal_aws_state_bucket."
+  type        = string
+  default     = "openbao-unseal/aws/03-backup-dev-bucket/terraform.tfstate"
+}
+

--- a/10-cluster/local/version.tf
+++ b/10-cluster/local/version.tf
@@ -12,6 +12,10 @@ terraform {
       version = "~> 0.16"
       source  = "infisical/infisical"
     }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.0"
+    }
   }
 }
 

--- a/10-cluster/scaleway/.terraform.lock.hcl
+++ b/10-cluster/scaleway/.terraform.lock.hcl
@@ -1,26 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version = "6.57.1"
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.4.1"
+  constraints = "~> 2.0"
   hashes = [
-    "h1:Mz2BVjntgeXCYLdhPCpgTBvGNPmxJBJxqq5M4r27Hc8=",
-    "zh:2d29e22480a81c21fb3f2fd52f9bd3ca4a82c37f3bb1b1036e881e42cddc75a1",
-    "zh:33aeb08e9973199b30f8a8e48a58dc67cfb6e32879f7a1c05c521899fe718f53",
-    "zh:37b7f977a7e7d45ad11d42958bc264873fb34573eee925915038ea05607abc9e",
-    "zh:41ebdcf4bcd073a01d58505a5f5118b85668de357d2d9f266926923e817a1842",
-    "zh:43093dfc3559c2c0467c92f48b29ae0221d52e912fce03dd77abd90806fdcc7d",
-    "zh:63b4252933e828d3590c0c64b827ec0f8955aa52df719fe67f45a846111fccc4",
-    "zh:7473b036e9f8167c7a09e4865de95d07922eae6a612b94e819d44c87ba5298de",
-    "zh:783c73e66bf50a74983803e1ec6d6237bae2891f9d4fd4824cfd5350121552ae",
-    "zh:83681e1d8d002048b76d7144cb96c8c8501dc973d1fee41b7579a46ad9eb04c2",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:b08b4168d4e2a81badbbe65d95f692ed3292c2b71cd00b9889a3bb7cf54c1188",
-    "zh:b4320ca25f4f67beebcbd6563ece2e490bd9dcb0a7e59b5d7a437ddaf53768ed",
-    "zh:d7f99254d6e05bac3dffae9b437c47cd807b4e66d941e56364be0a28ead418bd",
-    "zh:e433e91689758a341c91840cc7b5d3a3c5089004766d20659d57199b88ad8a5f",
-    "zh:e4c5a9b0f96a5fe2b5ed5592d4c2ac33240cf5308bcb14e52d6f2e0eb183a014",
-    "zh:fc4b554ae98e40e3ab6878ec9501ba2b05213d30668ee357d48b207993ffbe03",
+    "h1:VpNKqlWiwV5e6jgspQ0OqqC1hHZ6uiOzM7/irRAmj4o=",
+    "h1:pNEBlwrLd7hJ+bBZwxVM3jfV9HmsueDD83xyXAFEQR8=",
+    "zh:4729bb3f5a6162c6662e51ddd6fce39206632c98109db9969fba65fd063da1af",
+    "zh:4be9471fcf2dfc72bb70a91f526e3c6e35f5f9f656b2ee6eebcb8acdeeecfb48",
+    "zh:526625afb495fb01e3cf48cc4bd974340ac0b7c6fe5f1a6daac5f8aed3836f9e",
+    "zh:6c1287366f8841288108cda7801092940c0dc80a5bad28bf012825c921bcc5ef",
+    "zh:707b2aa4f93a0d8682e81890bfaa5c7199f3e6d2fdbafbf4f89996cb7f0e291e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fb382f0b266e98d5c78a39426b063aefffce566f12b19fd722a93e8127108af",
+    "zh:89092c1ab478457266ca4c064c4ee77225a2de01a37a1a15c542f978e3db8a32",
+    "zh:b066a49f3fe3ff49427f2b93b919c7c34ed01236fd594283cb1baf1521566464",
+    "zh:d5d66dd91f7a58e397e10360f45a92a1a3a66388a67036e30b426b873f58667c",
+    "zh:df2479f69e15843dc1671127018b7fcc1a0ddc8f93afb61e730c1ad5c3e365e8",
+    "zh:f1881dec0cd543bc351299a5bc08743716b7eed1043a43da4347fd42b1cc0563",
+    "zh:fe03df7ead78b43137ef9d805ae638daa86516345d3c44e81a2944d3d256e587",
   ]
 }
 

--- a/10-cluster/scaleway/env/02-cluster-staging.tfvars
+++ b/10-cluster/scaleway/env/02-cluster-staging.tfvars
@@ -1,2 +1,9 @@
 cluster_name = "scaleway-homelab"
-node_count = 2
+node_count   = 2
+
+# Cross-root state reads — see 00-foundation/scaleway/env/00-remote-state-backend.tfvars
+# for the full bucket list.
+backup_scaleway_state_bucket    = "id-terraform-state-03-storage-scaleway"
+backup_scaleway_state_key       = "backup/scaleway/03-backup-dev-bucket/terraform.tfstate"
+openbao_unseal_aws_state_bucket = "id-terraform-state-02-encryption-aws"
+openbao_unseal_aws_state_key    = "openbao-unseal/aws/03-backup-dev-bucket/terraform.tfstate"

--- a/10-cluster/scaleway/main.tf
+++ b/10-cluster/scaleway/main.tf
@@ -105,27 +105,59 @@ resource "null_resource" "update_kubeconfig" {
 }
 
 
+# Credentials for the cross-root Scaleway state reads below: read straight
+# from the scw CLI's own config (the same credentials `provider "scaleway"
+# {}` already uses implicitly everywhere else) instead of requiring
+# AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY set ambiently. Terraform's s3
+# backend/data source has no notion of the scw CLI's own config format —
+# this bridges the two credential systems automatically, so any admin who
+# already has `scw` configured (a repo-wide prerequisite already) needs zero
+# extra setup.
+data "external" "scw_credentials" {
+  program = ["sh", "-c", "jq -n --arg ak \"$(scw config get access-key)\" --arg sk \"$(scw config get secret-key)\" '{access_key:$ak, secret_key:$sk}'"]
+}
+
+# Shared technical attributes for every cross-root Scaleway state read below
+# — not "config" in the meaningful sense (they never vary), just the
+# Scaleway S3-compatible endpoint mechanics repeated per data source
+# otherwise. The actual config — which bucket/key, i.e. which root's state —
+# is parametrized via variables.tf + env/, visible there instead of buried
+# here.
+locals {
+  scaleway_state_backend = {
+    region                      = "fr-par"
+    access_key                  = data.external.scw_credentials.result.access_key
+    secret_key                  = data.external.scw_credentials.result.secret_key
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
+  }
+}
+
 # scaleway-s3-credentials source: 03-storage/scaleway's "backup" bucket + its
 # scoped workload identity. Same remote state key 05-secrets/openbao/managed
 # reads as its own `backup_scaleway` data source.
 data "terraform_remote_state" "backup_scaleway" {
   backend = "s3"
-  config = {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
-    key    = "backup/scaleway/03-backup-dev-bucket/terraform.tfstate"
-  }
+  config = merge(local.scaleway_state_backend, {
+    bucket = var.backup_scaleway_state_bucket
+    key    = var.backup_scaleway_state_key
+  })
 }
 
 # AWS credentials OpenBao reads at startup for KMS auto-unseal (seal "awskms")
 # — source: 02-encryption/aws's KMS key + dedicated IAM user.
 data "terraform_remote_state" "openbao_unseal_aws" {
   backend = "s3"
-  config = {
-    bucket = "id-terraform-state20260612164136440800000001"
-    region = "eu-west-3"
-    key    = "openbao-unseal/aws/03-backup-dev-bucket/terraform.tfstate"
-  }
+  config = merge(local.scaleway_state_backend, {
+    bucket = var.openbao_unseal_aws_state_bucket
+    key    = var.openbao_unseal_aws_state_key
+  })
 }
 
 resource "kubernetes_namespace" "openbao" {

--- a/10-cluster/scaleway/variables.tf
+++ b/10-cluster/scaleway/variables.tf
@@ -57,3 +57,25 @@ variable "argocd_admin_password_hash" {
   # default     = ""
 }
 
+# ── Cross-root state reads (Scaleway state buckets, see 00-foundation/scaleway) ──
+
+variable "backup_scaleway_state_bucket" {
+  description = "Scaleway bucket holding 03-storage/scaleway's remote state."
+  type        = string
+}
+
+variable "backup_scaleway_state_key" {
+  description = "Object key for 03-storage/scaleway's state within backup_scaleway_state_bucket."
+  type        = string
+}
+
+variable "openbao_unseal_aws_state_bucket" {
+  description = "Scaleway bucket holding 02-encryption/aws's remote state."
+  type        = string
+}
+
+variable "openbao_unseal_aws_state_key" {
+  description = "Object key for 02-encryption/aws's state within openbao_unseal_aws_state_bucket."
+  type        = string
+}
+

--- a/10-cluster/scaleway/version.tf
+++ b/10-cluster/scaleway/version.tf
@@ -1,12 +1,21 @@
 terraform {
-  # Remote state in the org-wide bucket (state-backend/). Creds: see mise.toml.
+  # Migrated to the dedicated Scaleway state bucket (00-foundation/scaleway,
+  # state_buckets["cluster_scaleway"]).
   backend "s3" {
-    bucket               = "id-terraform-state20260612164136440800000001"
-    region               = "eu-west-3"
-    workspace_key_prefix = "cluster/scaleway"
-    key                  = "terraform.tfstate"
-    encrypt              = true
-    use_lockfile         = true
+    bucket                      = "id-terraform-state-10-cluster-scaleway"
+    region                      = "fr-par"
+    workspace_key_prefix        = "cluster/scaleway"
+    key                         = "terraform.tfstate"
+    encrypt                     = true
+    use_lockfile                = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    use_path_style              = true
+    endpoints = {
+      s3 = "https://s3.fr-par.scw.cloud"
+    }
   }
 
   required_providers {
@@ -34,6 +43,10 @@ terraform {
     #   source  = "infisical/infisical"
     #   version = "~> 0.16"
     # }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 2.0"
+    }
   }
 }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@ The `.terraform.lock.hcl` in each root must cover **both** `darwin_arm64` (local
 
 ```bash
 terraform -chdir=00-foundation/aws                providers lock -platform=darwin_arm64 -platform=linux_amd64
+terraform -chdir=00-foundation/scaleway             providers lock -platform=darwin_arm64 -platform=linux_amd64
 terraform -chdir=01-iam/bootstrap/aws               providers lock -platform=darwin_arm64 -platform=linux_amd64
 terraform -chdir=01-iam/bootstrap/scaleway          providers lock -platform=darwin_arm64 -platform=linux_amd64
 terraform -chdir=01-iam/workload/scaleway           providers lock -platform=darwin_arm64 -platform=linux_amd64
@@ -77,18 +78,38 @@ modules/
   scaleway-machine-identity/   # shared: IAM application + map of policies +
                                #   rotating API key. Used by every Scaleway
                                #   identity below instead of copy-pasted HCL.
-  scaleway-bucket-with-identity/ # shared: one bucket + one scoped identity
-                               #   (wraps scaleway-machine-identity). Used by
-                               #   03-storage/scaleway's for_each over
-                               #   var.buckets — add a tool bucket there by
-                               #   adding a map entry, not new resources.
+  scaleway-bucket-with-identity/ # shared: one bucket + (by default,
+                               #   create_identity = true) one scoped
+                               #   identity, generated/unique-by-construction
+                               #   from bucket_name (wraps
+                               #   scaleway-machine-identity). Used by
+                               #   03-storage/scaleway's and
+                               #   00-foundation/scaleway's for_each over
+                               #   var.buckets/var.state_buckets — add a
+                               #   bucket there by adding a map entry, not
+                               #   new resources. expiration_enabled = false
+                               #   opts a bucket's current-version object out
+                               #   of ever expiring (state buckets).
 00-foundation/
   aws/                         # domain: the base AWS layer everything else
-                               #   depends on — the S3 bucket holding every
-                               #   root's remote state, PLUS the GitHub OIDC
-                               #   provider + the one role (terraform-state-
-                               #   access) every workflow in this repo assumes
-                               #   for state R/W. Admin-applied.
+                               #   used to depend on — the S3 bucket that USED
+                               #   TO hold every root's remote state (now only
+                               #   its own — see scaleway/ below), PLUS the
+                               #   GitHub OIDC provider + the one role
+                               #   (terraform-state-access) every workflow in
+                               #   this repo assumes for state R/W.
+                               #   Admin-applied.
+  scaleway/                    # domain: where every other root's state now
+                               #   lives (migrated 2026-08-19) — one dedicated
+                               #   bucket PER CONSUMING ROOT (var.state_buckets),
+                               #   not one shared bucket, since Scaleway IAM
+                               #   can only scope Object Storage permissions
+                               #   at the project level. See its README for
+                               #   the confirmed backend config (S3 native
+                               #   locking works, path-style + skip_s3_checksum
+                               #   required) and the still-open follow-up
+                               #   (.github/actions/terraform/action.yml isn't
+                               #   updated for Scaleway-hosted backends yet).
 01-iam/                        # domain: IAM identities & grants (non-AWS)
   bootstrap/
     aws/                       #   CI role scoped to 02-encryption/aws only
@@ -151,15 +172,24 @@ modules/
 ```
 
 **The dependency spine** runs forward: `00-foundation/aws` (bucket + CI's AWS
-role) → everything else, since every other root's backend points at that
-bucket. `terraform-state-access` (the role every workflow assumes by default)
-is scoped to exactly S3 read/write on the state bucket — no IAM-management
-capability at all. Only one other role exists, `01-iam/bootstrap/aws`'s
-`openbao-unseal-ci`, and it's narrowly scoped too: KMS + IAM user/access-key
-CRUD under `/openbao/`, nothing broader, plus (via a `terraform_remote_state`
-lookup, not a hardcoded ARN) the same state-bucket policy
-`terraform-state-access` uses, so it can read/write the bucket for its own
-backend. (This two-role setup replaced a larger system, retired 2026-07-30: the
+role) → everything else, since every other root's backend USED TO point at
+that bucket. As of the AWS→Scaleway state-backend migration
+(`00-foundation/scaleway`, 2026-08-19), only `00-foundation/aws` itself still
+does — every other root's state now lives in its own dedicated bucket under
+`00-foundation/scaleway` instead (one bucket per root, see that root's
+README for why). `terraform-state-access` (the role every workflow assumes
+by default) is scoped to exactly S3 read/write on the AWS state bucket — no
+IAM-management capability at all — but is now only load-bearing for roots
+that still live there (`00-foundation/aws` itself); its continued presence
+in `.github/actions/terraform/action.yml` as a required input is dead weight
+for every migrated root's workflow until that action is updated to pass
+Scaleway credentials instead (follow-up work, not yet done). Only one other
+role exists, `01-iam/bootstrap/aws`'s `openbao-unseal-ci`, and it's narrowly
+scoped too: KMS + IAM user/access-key CRUD under `/openbao/`, nothing
+broader, plus (via a `terraform_remote_state` lookup, not a hardcoded ARN)
+the same state-bucket policy `terraform-state-access` uses — a grant that's
+now vestigial too, since `01-iam/bootstrap/aws`'s own backend also migrated
+to Scaleway and no longer needs it. (This two-role setup replaced a larger system, retired 2026-07-30: the
 original `01-iam/bootstrap/aws` + `01-iam/ci-managed/aws-state-access` together
 built a "CI can safely mint further IAM roles" mechanism — a permissions
 boundary + a policy letting the CI role create/attach *any* other role under a
@@ -206,6 +236,64 @@ Same bootstrap pattern as `local/`, but with the Kapsule cluster + node pool (`D
 ### `00-foundation/aws/`
 
 The shared org S3 bucket holding **every** root's remote state (built on `terraform-aws-modules/s3-bucket`: versioning, SSE, public-access block, TLS-only). Chicken-and-egg: its own state lives in the bucket it creates (one-time local-state bootstrap — see its README). Also creates the GitHub OIDC provider and the one role, `terraform-state-access` (via `terraform-aws-modules/iam`), every GitHub Actions workflow in this repo assumes — trust scoped to `repo:IntegratedDynamic/infrastructure:*`, policy scoped to exactly S3 list/get/put/delete on the state bucket, nothing else. Wired to CI via `vars.AWS_TERRAFORM_ROLE_ARN`. Applied by an admin (this root creates the very identity CI would otherwise need to apply it). See its README.
+
+### `00-foundation/scaleway/`
+
+Scaleway counterpart to `00-foundation/aws/` — and, as of 2026-08-19, where
+every root's state actually lives except `00-foundation/aws` itself. Unlike
+the AWS bucket (one bucket, many `workspace_key_prefix` values), this is
+**one dedicated Object Storage bucket per consuming root module**
+(`var.state_buckets`, a `for_each` map — add a future root's bucket by
+adding a map entry, no new resources) — Scaleway IAM can only scope Object
+Storage permissions at the project level, so a shared bucket would give every
+root's CI identity read/write on every other root's state with no way to
+narrow it, worse than the AWS setup's already-documented lack of per-root
+isolation. Built on `modules/scaleway-bucket-with-identity` (the same module
+`03-storage/scaleway` uses) — as of 2026-08-19, each bucket gets its **own**
+dedicated identity by default (`create_identity = true`, generated/
+unique-by-construction names from `bucket_name`), not one shared identity
+for all buckets; a root needing broader Scaleway rights sets
+`create_identity = false` and gets its identity in `01-iam/` instead. This
+root's own state is self-hosted here too
+(`state_buckets["foundation_scaleway"]`) — bootstrapped the same one-time
+chicken-and-egg way `00-foundation/aws` was: created while its state still
+lived in the AWS bucket, then repointed and migrated.
+
+The migration procedure was rehearsed first against a throwaway root
+(`99-scratch/migration-test`, since deleted) — confirmed working — then
+rolled out to every real domain (`01-iam/*`, `02-encryption/aws`,
+`03-storage/scaleway`, `04-vpn/*`, `05-secrets/openbao/*`,
+`06-monitoring/grafana/*`, `10-cluster/scaleway`) plus this root itself. See
+this root's README for the confirmed findings: `use_lockfile` native S3
+locking works against Scaleway, and the required backend config is
+`use_path_style = true` + `skip_s3_checksum = true` + a literal
+`endpoints.s3` — a Terraform hard constraint (`backend` blocks can't
+reference variables) that's why those five lines are repeated verbatim in
+every migrated root's `version.tf` rather than parametrized.
+
+Every `data "terraform_remote_state"` cross-root read repo-wide (there are
+~11 of them — see `05-secrets/openbao/managed/main.tf` for the densest
+cluster, 4 in one file) was updated to point at the new buckets too, and
+**parametrized**: bucket/key are now named variables set in that root's
+`env/*.tfvars` (visible as config), not hardcoded literals in `.tf`. The
+`data` source's own technical Scaleway-endpoint attributes (region,
+`skip_*`, `endpoints`) — unlike a `backend` block — CAN reference locals, so
+each file with cross-root reads defines one `local.scaleway_state_backend`
+merged into every `config` block instead of repeating those five lines per
+data source.
+
+**Known follow-up, not yet done**: `.github/actions/terraform/action.yml`
+still only knows how to assume an AWS role for backend state R/W — every
+migrated root's workflow needs it updated to pass Scaleway credentials via
+`-backend-config` instead (needed *specifically* for roots that also carry a
+real `provider "aws"` block, e.g. `02-encryption/aws`, since Terraform's s3
+backend and that provider both read `AWS_ACCESS_KEY_ID`/
+`AWS_SECRET_ACCESS_KEY` — colliding if both need real values at once).
+Locally this was worked around per-command with an explicit
+`-backend-config=<gitignored file>` instead of ambient env vars. The
+rehearsal bucket (`state_buckets["scratch"]`) is intentionally left in
+place, `prevent_destroy` included — cleanup is a manual admin action on
+their own timeline, not something to automate away.
 
 ### `01-iam/bootstrap/aws/`
 

--- a/mise.toml
+++ b/mise.toml
@@ -170,6 +170,7 @@ kubectl logs -n openbao "job/$job" --tail=5
 description = "Re-generate all .terraform.lock.hcl files for darwin_arm64 + linux_amd64"
 run = """
 terraform -chdir=00-foundation/aws                providers lock -platform=darwin_arm64 -platform=linux_amd64
+terraform -chdir=00-foundation/scaleway             providers lock -platform=darwin_arm64 -platform=linux_amd64
 terraform -chdir=01-iam/bootstrap/aws               providers lock -platform=darwin_arm64 -platform=linux_amd64
 terraform -chdir=01-iam/bootstrap/scaleway          providers lock -platform=darwin_arm64 -platform=linux_amd64
 terraform -chdir=01-iam/workload/scaleway           providers lock -platform=darwin_arm64 -platform=linux_amd64

--- a/modules/scaleway-bucket-with-identity/main.tf
+++ b/modules/scaleway-bucket-with-identity/main.tf
@@ -1,3 +1,18 @@
+locals {
+  # Auto-generated, unless the caller supplies its own — derived from
+  # bucket_name, which Scaleway already guarantees is globally unique, so
+  # these are unique-by-construction with zero extra machinery (no random
+  # suffix needed) and traceable back to their bucket at a glance. Suffixes
+  # kept short (Scaleway IAM application/policy names cap at 64 runes) and
+  # truncated defensively with substr() so a future long bucket_name can't
+  # blow the limit and hard-fail the apply.
+  identity_application_name        = coalesce(var.identity_application_name, substr("${var.bucket_name}-access", 0, 64))
+  identity_application_description = coalesce(var.identity_application_description, "Machine identity scoped to the ${var.bucket_name} bucket.")
+  identity_policy_name             = coalesce(var.identity_policy_name, substr("${var.bucket_name}-objects", 0, 64))
+  identity_policy_description      = coalesce(var.identity_policy_description, "Object-level read/write on the ${var.bucket_name} bucket. Project-scoped: Scaleway IAM can't scope below project level.")
+  api_key_description              = coalesce(var.api_key_description, "Terraform-managed credentials for ${var.bucket_name}.")
+}
+
 resource "scaleway_object_bucket" "this" {
   name   = var.bucket_name
   region = var.region
@@ -10,8 +25,14 @@ resource "scaleway_object_bucket" "this" {
     id      = var.lifecycle_rule_id
     enabled = true
 
-    expiration {
-      days = var.retention_days
+    # Disabled (expiration_enabled = false) for callers whose current-version
+    # object must never expire regardless of age — e.g. Terraform state
+    # buckets, where only noncurrent_version_expiration below applies.
+    dynamic "expiration" {
+      for_each = var.expiration_enabled ? [var.retention_days] : []
+      content {
+        days = expiration.value
+      }
     }
 
     noncurrent_version_expiration {
@@ -54,16 +75,20 @@ resource "scaleway_object_bucket_server_side_encryption_configuration" "this" {
   }
 }
 
+# create_identity defaults to true: most buckets want their own scoped
+# identity. A caller that already has (or will create, e.g. in 01-iam/) a
+# broader identity of its own sets this false instead.
 module "identity" {
   source = "../scaleway-machine-identity"
+  count  = var.create_identity ? 1 : 0
 
-  application_name        = var.identity_application_name
-  application_description = var.identity_application_description
+  application_name        = local.identity_application_name
+  application_description = local.identity_application_description
 
   policies = {
     default = {
-      name        = var.identity_policy_name
-      description = var.identity_policy_description
+      name        = local.identity_policy_name
+      description = local.identity_policy_description
       rules = [
         {
           project_ids          = [var.project_id]
@@ -73,6 +98,6 @@ module "identity" {
     }
   }
 
-  project_id           = var.project_id
-  api_key_description  = var.api_key_description
+  project_id          = var.project_id
+  api_key_description = local.api_key_description
 }

--- a/modules/scaleway-bucket-with-identity/moves.tf
+++ b/modules/scaleway-bucket-with-identity/moves.tf
@@ -1,0 +1,8 @@
+# create_identity's `count` on module.identity (added so callers can opt out)
+# changed its instance address from the countless form to `[0]`. This applies
+# automatically to every caller of this module — no per-call-site moved block
+# needed.
+moved {
+  from = module.identity
+  to   = module.identity[0]
+}

--- a/modules/scaleway-bucket-with-identity/outputs.tf
+++ b/modules/scaleway-bucket-with-identity/outputs.tf
@@ -14,12 +14,12 @@ output "bucket_endpoint" {
 }
 
 output "access_key" {
-  description = "Public access key for the scoped workload identity."
-  value       = module.identity.access_key
+  description = "Public access key for the scoped workload identity, or null when create_identity = false."
+  value       = try(module.identity[0].access_key, null)
 }
 
 output "secret_key" {
-  description = "Secret access key for the scoped workload identity."
+  description = "Secret access key for the scoped workload identity, or null when create_identity = false."
   sensitive   = true
-  value       = module.identity.secret_key
+  value       = try(module.identity[0].secret_key, null)
 }

--- a/modules/scaleway-bucket-with-identity/variables.tf
+++ b/modules/scaleway-bucket-with-identity/variables.tf
@@ -47,6 +47,12 @@ variable "cold_storage_transition_days" {
   default     = 90
 }
 
+variable "expiration_enabled" {
+  description = "Whether current-version objects expire after retention_days. Default true (existing behavior). Set false for buckets whose current version must never expire regardless of age (e.g. Terraform state buckets) — noncurrent_version_expiry_days still applies either way."
+  type        = bool
+  default     = true
+}
+
 # ── Identity (modules/scaleway-machine-identity) ────────────────────────────
 
 variable "project_id" {
@@ -54,26 +60,34 @@ variable "project_id" {
   type        = string
 }
 
+variable "create_identity" {
+  description = "Whether to create a dedicated machine identity (IAM application + policy + API key) scoped to this bucket. Default true — most buckets want their own least-privilege identity; set false when a caller already has (or will create, e.g. in 01-iam/) its own broader identity instead."
+  type        = bool
+  default     = true
+}
+
 variable "identity_application_name" {
-  description = "Name of the IAM application backing this bucket's workload identity."
+  description = "Name of the IAM application backing this bucket's workload identity. Left unset (null), auto-generated from bucket_name — which Scaleway already guarantees is globally unique — so it's unique-by-construction without extra machinery."
   type        = string
+  default     = null
 }
 
 variable "identity_application_description" {
-  description = "Description of the IAM application."
+  description = "Description of the IAM application. Auto-generated from bucket_name when unset."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "identity_policy_name" {
-  description = "Name of the IAM policy granting this identity access to the bucket."
+  description = "Name of the IAM policy granting this identity access to the bucket. Auto-generated from bucket_name when unset — see identity_application_name."
   type        = string
+  default     = null
 }
 
 variable "identity_policy_description" {
-  description = "Description of the IAM policy."
+  description = "Description of the IAM policy. Auto-generated from bucket_name when unset."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "identity_permission_set_names" {
@@ -83,7 +97,7 @@ variable "identity_permission_set_names" {
 }
 
 variable "api_key_description" {
-  description = "Description of the generated API key."
+  description = "Description of the generated API key. Auto-generated from bucket_name when unset."
   type        = string
-  default     = ""
+  default     = null
 }


### PR DESCRIPTION
## Summary
- Adds `00-foundation/scaleway`: one dedicated Object Storage bucket per consuming root module (`var.state_buckets`), each with its own least-privilege identity by default (`create_identity`, generated/unique-by-construction names) — built on `modules/scaleway-bucket-with-identity` (same module `03-storage/scaleway` already used), extended with `expiration_enabled` and `create_identity`. Per-root buckets, not one shared bucket, because Scaleway IAM can only scope Object Storage permissions at the project level.
- Rehearsed the AWS → Scaleway backend migration on a throwaway root first (applied, repointed, migrated, verified, deleted), then rolled it out for real to every domain: `01-iam/*`, `02-encryption/aws`, `03-storage/scaleway`, `04-vpn/*`, `05-secrets/openbao/*`, `06-monitoring/grafana/*`, `10-cluster/scaleway`, and `00-foundation/scaleway`'s own state. `00-foundation/aws` stays on AWS permanently — it IS the AWS bucket.
- Parametrized every cross-root `data "terraform_remote_state"` read (~11 of them) — bucket/key are now variables in `env/*.tfvars`, not hardcoded literals — and gave each a `data "external"` block that reads credentials straight from the `scw` CLI's own config, so no `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` ever needs exporting by hand.
- Updates CLAUDE.md / `mise run lock` for the new topology.

## Verified, not just planned
Every migrated root: bucket created, backend repointed, `terraform init -migrate-state` run, confirmed via `terraform state list` + a clean `terraform plan` with zero `AWS_*` env vars set. A cluster/OpenBao/Grafana reset happened mid-work; `05-secrets/openbao/bootstrap` and `06-monitoring/grafana/{bootstrap,managed}` were re-applied to regenerate stale credentials — all clean now except `vault_approle_auth_backend_role_secret_id`, which looks like a non-idempotent Vault resource (wants replacement every plan regardless of changes) — pre-existing, not introduced here.

## Known, pre-existing, unrelated
`03-storage/scaleway`'s `loki`/`tempo` buckets: live retention still 30d, code says 1d since a commit that was never applied. Left alone.

## Deliberately out of scope (follow-up)
- `.github/actions/terraform/action.yml` still only assumes an AWS role for backend R/W — needs updating to pass Scaleway credentials via `-backend-config` for CI, since `02-encryption/aws`/`01-iam/bootstrap/aws` carry a real `provider "aws"` block that would collide with Scaleway creds in the same `AWS_*` env vars.
- The rehearsal's leftover bucket (`state_buckets["scratch"]`, `prevent_destroy` on) — kept intentionally, cleanup is the admin's own call.

## Test plan
- [x] `terraform validate` + `providers lock` (both platforms) on every touched root
- [x] Live migration + verification per root (state list / no-op plan)
- [x] Module change backward-compat verified on `03-storage/scaleway` (clean plan, no destroy/recreate)
- [x] Cross-root credential fix verified with zero ambient `AWS_*` env vars
- [ ] Update `.github/actions/terraform/action.yml` before any migrated root's CI workflow runs again

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMroWFCM477MaZJJ6DgDCd