### PR TITLE
fix: bump argocd-application-controller memory + priorityClassName

### DIFF
--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -13,7 +13,15 @@ locals {
   # 85% splits the difference), computed from the limit instead of a second
   # hardcoded literal so the two can't drift out of the recommended ratio:
   # https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/#mitigating-oomkilled-events-from-memory-spikes
-  argocd_controller_memory_limit_mib = 1000
+  #
+  # Bumped 1000 -> 1500 2026-08-20: confirmed live that 1000Mi + GOMEMLIMIT
+  # alone wasn't enough headroom for a full from-scratch tree resync (all
+  # ~30 Applications across every wave at once, not just the steady-state
+  # reconciliation loop the earlier 1000Mi figure was sized from) --
+  # GOMEMLIMIT only forces proactive GC, it can't shrink genuinely live
+  # working-set below what a full resync actually needs to hold in memory
+  # at once.
+  argocd_controller_memory_limit_mib = 1500
   argocd_controller_gomemlimit_mib   = floor(local.argocd_controller_memory_limit_mib * 0.85)
 }
 
@@ -212,6 +220,16 @@ dex:
 # same generous limit despite low observed idle usage (8m/131Mi).
 controller:
   replicas: 1
+  # Small node pool (see the "small nodes, no real headroom" comment on
+  # repoServer's sizing below) -- system-cluster-critical (built into every
+  # Kubernetes cluster, usable outside kube-system unlike
+  # system-node-critical) protects this pod specifically from the kubelet's
+  # own node-memory-pressure eviction (confirmed live 2026-08-20: this pod
+  # was evicted at 91% of a node's memory even while under its own
+  # container limit -- a different mechanism than the cgroup OOM kill
+  # GOMEMLIMIT below addresses) and gives it scheduling priority over
+  # everything else in this namespace.
+  priorityClassName: system-cluster-critical
   # GOMEMLIMIT (see the locals block above this resource): observed live
   # 2026-08-20 that even 2048Mi wasn't enough headroom during a full
   # 22-Application reconcile burst -- OOMKilled twice before stabilizing.


### PR DESCRIPTION
## Summary
- Confirmed live 2026-08-20: the earlier GOMEMLIMIT fix (1000Mi limit) wasn't enough headroom for a full from-scratch tree resync (~30 Applications, all waves at once) — the controller OOMKilled repeatedly, which is what was actually blocking `bootstrap`'s sync from progressing past wave 3 (every retry died with the controller mid-operation).
- Bumps `controller.resources.limits.memory` 1000Mi → 1500Mi (GOMEMLIMIT recomputed to 1275MiB, same 85% ratio).
- Adds `controller.priorityClassName: system-cluster-critical` — protects this pod from the kubelet's node-memory-pressure eviction specifically (a different mechanism than the cgroup OOM kill GOMEMLIMIT addresses; confirmed live this pod was evicted at 91% of a node's memory even while under its own container limit).

## Test plan
- [x] Applied live via `terraform apply -target=helm_release.argocd`; confirmed pod has `priorityClassName: system-cluster-critical`, `1500Mi` limit, `GOMEMLIMIT=1275MiB`
- [x] Retried a full bootstrap resync afterward — controller stayed `1/1 Running`, 0 restarts, through it