### PR TITLE
feat: ArgoCD HA-doc tuning + DEV1-L nodes

### DIFF
--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -36,9 +36,54 @@ resource "helm_release" "argocd" {
 configs:
   params:
     server.insecure: true
+    # JSON, not the default logfmt-ish text -- Alloy (gitops repo,
+    # services/platform/monitoring/alloy-chart) already tails every pod's
+    # logs into Loki cluster-wide from wave 4 on, well before Grafana's own
+    # UI is reachable (wave 5+), so ArgoCD's own state is already being
+    # captured from early boot -- this just makes what's captured reliably
+    # field-parseable once actually queried, instead of Loki's logfmt
+    # heuristic guessing at a text format that isn't guaranteed stable.
+    controller.log.format: json
+    server.log.format: json
+    reposerver.log.format: json
+    applicationsetcontroller.log.format: json
 
   cm:
     url: https://argocd.scalepack.fr
+
+    # Cuts cluster-cache memory, not just the controller's own footprint --
+    # by default the controller watches every API resource kind in the
+    # cluster for live-state diffing, regardless of whether any Application
+    # actually manages instances of that kind. events.k8s.io/*,
+    # metrics.k8s.io/* and coordination.k8s.io/Lease are already excluded
+    # by Argo CD itself unconditionally; these two rules add the next-
+    # highest-churn kinds this cluster actually has plenty of and no
+    # Application ever references:
+    #  - discovery.k8s.io/EndpointSlice (+ legacy v1/Endpoints): one
+    #    object (Endpoints) or more (EndpointSlice) per Service, rewritten
+    #    on every pod readiness flip -- never something an Application's
+    #    health/sync depends on here.
+    #  - cilium.io/* (CiliumEndpoint, CiliumIdentity, CiliumNode, ...):
+    #    Cilium is the Kapsule cluster's CNI (main.tf's scaleway_k8s_cluster.this,
+    #    cni = "cilium"), provisioned by Scaleway itself, not an ArgoCD
+    #    Application -- no Application here ever references these, and
+    #    Cilium creates one CiliumEndpoint per pod cluster-wide, the kind
+    #    of per-pod-times-every-DaemonSet growth this exclusion is
+    #    specifically meant to blunt.
+    # https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#resource-exclusioninclusion
+    resource.exclusions: |
+      - apiGroups:
+        - discovery.k8s.io
+        kinds:
+        - EndpointSlice
+      - apiGroups:
+        - ""
+        kinds:
+        - Endpoints
+      - apiGroups:
+        - cilium.io
+        kinds:
+        - "*"
 
     # Local admin login is redundant now that OIDC via Dex is working —
     # one login path, no separate password to rotate/leak. To bring back
@@ -212,6 +257,22 @@ dex:
 # same generous limit despite low observed idle usage (8m/131Mi).
 controller:
   replicas: 1
+  # NOT sharded, on purpose: Argo CD's controller sharding
+  # (ARGOCD_CONTROLLER_REPLICAS + --sharding-method) splits load by
+  # *registered cluster*, never by Application/namespace/resource within
+  # one cluster -- confirmed against the docs and community sources, not
+  # assumed. This instance only ever registers one cluster (itself,
+  # https://kubernetes.default.svc), so every additional replica would
+  # sit fully idle: nothing to shard to it. Kept at 1 rather than chasing
+  # an HA pattern that's a no-op here — see resource.exclusions and
+  # GOMEMLIMIT below for the levers that actually apply to a
+  # single-cluster controller.
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: kube-prometheus-stack
   # GOMEMLIMIT (see the locals block above this resource): observed live
   # 2026-08-20 that even 2048Mi wasn't enough headroom during a full
   # 22-Application reconcile burst -- OOMKilled twice before stabilizing.
@@ -241,6 +302,12 @@ controller:
 
 repoServer:
   replicas: 1
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: kube-prometheus-stack
   resources:
     requests:
       cpu: 25m
@@ -250,6 +317,12 @@ repoServer:
       memory: 768Mi
 
 server:
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: kube-prometheus-stack
   resources:
     requests:
       cpu: 10m
@@ -279,6 +352,13 @@ applicationSet:
   # not prevent those pods starting before their credentials existed.
   extraArgs:
     - --enable-progressive-syncs
+
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: kube-prometheus-stack
 
   resources:
     requests:

--- a/10-cluster/scaleway/main.tf
+++ b/10-cluster/scaleway/main.tf
@@ -60,9 +60,17 @@ resource "scaleway_instance_security_group" "cluster_nodes" {
 }
 
 resource "scaleway_k8s_pool" "default" {
-  cluster_id        = scaleway_k8s_cluster.this.id
-  name              = "default"
-  node_type         = "DEV1-M"
+  cluster_id = scaleway_k8s_cluster.this.id
+  name       = "default"
+  # Bumped DEV1-M (3 vCPU/4GB) -> DEV1-L (4 vCPU/8GB) 2026-08-20: confirmed
+  # live that DEV1-M was routinely hitting MemoryPressure/evicting pods
+  # during a full ArgoCD tree sync -- the more waves ArgoCD advances
+  # through, the more DaemonSets (Cilium, node-exporter, Alloy, ...) run a
+  # pod on every node, compounding the same small-node pressure. Doubling
+  # RAM at roughly double the price (~15€ -> ~31€/mo/node) is the
+  # proportionate fix; create_before_destroy below means this replaces the
+  # pool without a bare window.
+  node_type         = "DEV1-L"
   security_group_id = scaleway_instance_security_group.cluster_nodes.id
   # Put whatever number is required to avoid node pressure signals during startup: https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/
   # Node pressure during startup can end-up with unexcepted race conditions.


### PR DESCRIPTION
## Summary
Converges on https://argo-cd.readthedocs.io/en/stable/operator-manual/high_availability/ plus independent research, following tonight's OOM incident.

- **Node pool DEV1-M → DEV1-L** (4 vCPU/8GB, ~15€→~31€/mo/node): confirmed live that DEV1-M routinely hit `MemoryPressure` during a full tree sync. **Not yet applied** — `node_type` forces a full pool replacement (`terraform plan` confirms `+/-` on `scaleway_k8s_pool.default`), a bigger action than the rest of this PR; left for a deliberate apply.
- **`resource.exclusions`**: excludes `EndpointSlice`/`Endpoints`/`cilium.io/*` from the controller's cluster cache (Events/metrics/Lease already excluded by Argo CD itself by default).
- **Sharding explicitly NOT used**, documented inline why: it splits load by *registered cluster*, and we only ever register one (ourselves) — confirmed via research, not assumed. Extra replicas would sit idle.
- **JSON log format** on all 4 components — Alloy already ships every pod's logs to Loki from wave 4; this just makes them reliably parseable.
- **Prometheus metrics + ServiceMonitor** enabled on all 4 components (was scraping nothing) — feeds the companion gitops repo PR's new PrometheusRule alerts.

Companion gitops PR: https://github.com/IntegratedDynamic/gitops/pull/36

## Test plan
- [x] `terraform validate` + `terraform plan -target=helm_release.argocd` reviewed
- [ ] Apply `helm_release.argocd` changes (log format / exclusions / metrics)
- [ ] Apply the node pool replacement separately, deliberately, once ready