### PR TITLE
docs: update backup-now's node-agent selector note post-CSI switch

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -144,9 +144,12 @@ run = 'sudo wg-quick down "$(pwd)/generated/${usage_peer?}.conf"'
 # values-scaleway.yaml (gitops repo) — see that file + this repo's
 # services/platform/gateway/config/README.md for the full restore-hook
 # writeup. Selecting the velero pod by the `name=velero` label (not
-# `app.kubernetes.io/name=velero`, which the node-agent DaemonSet pods
-# share) — `kubectl exec deploy/velero` has been observed picking a
-# node-agent pod instead, confirmed live 2026-08-14.
+# `app.kubernetes.io/name=velero`) — historically also matched the
+# node-agent DaemonSet's pods, causing `kubectl exec deploy/velero` to pick
+# the wrong one (confirmed live 2026-08-14); moot since infra#75 dropped
+# that DaemonSet entirely (grafana-data now backs up via CSI VolumeSnapshot,
+# not kopia file-system-backup), but the narrower selector is still the
+# more correct one to keep.
 
 [tasks.backup-now]
 description = "Trigger an on-demand backup: both Velero schedules + an OpenBao snapshot"


### PR DESCRIPTION
## Summary

gitops#38 (infra#75) dropped Velero's node-agent DaemonSet once `grafana-data` moved to CSI VolumeSnapshot backup — the selector-collision comment on `backup-now` no longer has a node-agent pod to worry about. Narrower selector kept as-is, just updating the rationale.

Confirmed live: re-ran `mise run backup-now` after today's cluster rebuild — `velero backup describe` now shows `CSI Snapshots` for `monitoring/grafana`, not the old kopia `Pod Volume Backups`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRR5FWhTCtZLux99dqH4x8