### PR TITLE
feat: Argo Workflows log-archive bucket + OpenBao credentials

### DIFF
--- a/03-storage/scaleway/env/03-backup-dev-bucket.tfvars
+++ b/03-storage/scaleway/env/03-backup-dev-bucket.tfvars
@@ -85,4 +85,24 @@ buckets = {
     retention_days        = 1
     cold_storage_enabled  = false
   }
+  argo_workflows_logs = {
+    bucket_name             = "argo-workflows-logs-dev-id"
+    identity_app_prefix     = "argo-workflows-logs-k8s"
+    identity_policy_prefix  = "argo-workflows-logs-objects"
+    identity_purpose        = "grants the Argo Workflows controller object read/write for archived container logs (artifactRepository.archiveLogs)"
+    api_key_purpose         = "Argo Workflows log-archive credentials"
+    api_key_consumer        = "Consumed via OpenBao (kv/apps/argo-workflows/scaleway-log-archive-credentials) → ESO → Kubernetes Secret"
+
+    # Same rolling-expiry shape as loki/tempo above: archived run logs are a
+    # debugging aid (mainly for CronWorkflow runs whose pods already got GC'd
+    # by podGC), not a durability target — no need for versioning/GLACIER.
+    # 1 day, matching loki/tempo: kept deliberately tight to bound cost —
+    # useful for debugging a run and any consecutive retrigger of it, not a
+    # backlog to browse days later. No versioning either — Argo's own S3
+    # artifact driver does plain unversioned PUT/GET by key, nothing about
+    # its integration relies on bucket versioning.
+    versioning_enabled    = false
+    retention_days        = 1
+    cold_storage_enabled  = false
+  }
 }

--- a/03-storage/scaleway/outputs.tf
+++ b/03-storage/scaleway/outputs.tf
@@ -95,3 +95,21 @@ output "tempo_workload_secret_key" {
   description = "Secret access key for the scoped Tempo Kubernetes workload identity."
   value       = module.buckets["tempo"].secret_key
 }
+
+# ── Argo Workflows log archive (separate bucket + identity) ──────────────────
+
+output "argo_workflows_logs_bucket_name" {
+  description = "Provisioned Argo Workflows log-archive bucket name."
+  value       = module.buckets["argo_workflows_logs"].bucket_name
+}
+
+output "argo_workflows_logs_workload_access_key" {
+  description = "Public access key for the scoped Argo Workflows log-archive Kubernetes workload identity."
+  value       = module.buckets["argo_workflows_logs"].access_key
+}
+
+output "argo_workflows_logs_workload_secret_key" {
+  sensitive   = true
+  description = "Secret access key for the scoped Argo Workflows log-archive Kubernetes workload identity."
+  value       = module.buckets["argo_workflows_logs"].secret_key
+}

--- a/05-secrets/openbao/managed/main.tf
+++ b/05-secrets/openbao/managed/main.tf
@@ -539,6 +539,23 @@ resource "vault_kv_secret_v2" "tempo_scaleway_s3_credentials" {
   })
 }
 
+# apps/argo-workflows/scaleway-log-archive-credentials — the Argo Workflows
+# controller's own object-storage credentials for archiving container logs
+# (artifactRepository.archiveLogs, gitops repo services/platform/argo-
+# workflows/chart values-scaleway.yaml). Separate bucket + IAM key from every
+# other tool bucket (03-storage/scaleway/env/*.tfvars' argo_workflows_logs
+# entry) — same "one bucket, one identity, per consumer, never shared"
+# contract (03-storage/README.md) as thanos/loki/tempo above.
+resource "vault_kv_secret_v2" "argo_workflows_logs_scaleway_s3_credentials" {
+  mount = vault_mount.kv.path
+  name  = "apps/argo-workflows/scaleway-log-archive-credentials"
+
+  data_json = jsonencode({
+    SCW_ACCESS_KEY = data.terraform_remote_state.backup_scaleway.outputs.argo_workflows_logs_workload_access_key
+    SCW_SECRET_KEY = data.terraform_remote_state.backup_scaleway.outputs.argo_workflows_logs_workload_secret_key
+  })
+}
+
 # apps/argo-workflows/scaleway-state-credentials — read by the gitops repo's
 # Argo Workflows CronWorkflow (services/platform/argo-workflows) for both its
 # own `terraform init` backend (this root's own bucket, R/W) and the


### PR DESCRIPTION
## Summary
- New dedicated Scaleway bucket + scoped identity (`03-storage/scaleway`, `argo_workflows_logs`) for the Argo Workflows controller's `artifactRepository.archiveLogs` — 1-day retention, no versioning (Argo's S3 artifact driver does plain unversioned PUT/GET by key).
- Companion OpenBao KV secret (`05-secrets/openbao/managed`) exposing the credentials to ESO.

Companion PR (gitops repo, [#44](https://github.com/IntegratedDynamic/gitops/pull/44)): wires this bucket into the Argo Workflows chart's `artifactRepository`, restructures `terraform-apply`'s WorkflowTemplate with a preflight self-heal step, and fixes two bugs found live-testing that restructure (an artifact-path regression, and an RBAC gap blocking the UI from reading archived logs).

## Test plan
- [x] `terraform plan` clean against `03-storage/scaleway` and `05-secrets/openbao/managed`
- [x] Already applied live during this session — both roots' resources exist and are in use by the gitops-side PR's live testing
- [ ] No `10-cluster/scaleway` apply needed for this repo's own changes — only the gitops repo's branch pin needs reverting to `main` once #44 merges