### PR TITLE
feat: default OpenBao roots to internal cluster DNS over the tunnel

### DIFF
--- a/04-vpn/wireguard-site-to-site/README.md
+++ b/04-vpn/wireguard-site-to-site/README.md
@@ -93,20 +93,46 @@ whichever node currently has a live pod), so `wg.scalepack.fr` — the
 other `*.scalepack.fr` hostname in this cluster already relies on. See
 that chart's `templates/service.yaml` annotation.
 
-## Why the tunnel doesn't route to OpenBao's ClusterIP directly
+## Why the tunnel doesn't route to internal ClusterIPs directly
 
-An earlier design routed/NAT'd traffic to OpenBao's `ClusterIP` at the
+An earlier design routed/NAT'd traffic to a target's `ClusterIP` at the
 kernel level (`net.ipv4.ip_forward` + `iptables` MASQUERADE) — a dead end:
 Kapsule's kubelet doesn't allowlist that sysctl, and Scaleway's
 `kubelet_args` API refuses to widen the allowlist for this cluster's k8s
 version at all. Even where available, that's a cluster-wide relaxation for
 one workload's benefit — worth avoiding regardless.
 
-The gitops chart instead terminates the tunnel and proxies to OpenBao at
-the application layer (a `socat` sidecar resolving
-`openbao.openbao.svc.cluster.local` via ordinary in-cluster DNS) — no
-kernel routing, no sysctls, no dependency on OpenBao's `ClusterIP` being
-stable across a cluster rebuild.
+The gitops chart instead terminates the tunnel and proxies to each target
+at the application layer (`proxyTargets`, one `socat` sidecar per entry,
+resolving its target — e.g. `openbao.openbao.svc.cluster.local` — via
+ordinary in-cluster DNS) — no kernel routing, no sysctls, no dependency on
+any `ClusterIP` being stable across a cluster rebuild. This is also why DNS
+resolution alone (see "Internal cluster DNS" below) doesn't make an
+*arbitrary* internal address reachable: a peer's traffic still needs a
+listener on the tunnel pod for the specific target port, so a new address
+means adding a `proxyTargets` entry, not just a DNS answer.
+
+## Internal cluster DNS
+
+The tunnel server's `dns` sidecar (gitops repo's
+`services/platform/wireguard-site-to-site/config`, `dnsInternalZones`)
+answers any hostname under the `svc` or `cluster.local` suffixes with its
+own tunnel address, instead of one hostname hardcoded per target — so a
+peer resolves any internal Service name generically (both the full
+`<name>.<namespace>.svc.cluster.local` form and the short
+`<name>.<namespace>.svc` form Argo Workflows already uses in-cluster).
+`*.scalepack.fr` split-DNS and the `proxy-gateway` sidecar it fed (SNI
+passthrough to Envoy Gateway, for OIDC-gated web UIs) were removed
+2026-08-24 (infrastructure#81) — this domain is for machine credentials
+reaching an internal API, not human OIDC/UI login, which stays on the
+public route untouched.
+
+With the tunnel up, `dig openbao.openbao.svc.cluster.local` should resolve
+to the tunnel's own address and `curl
+http://openbao.openbao.svc.cluster.local:8200/v1/sys/health` should reach
+OpenBao through the full chain (tunnel → gitops's `proxy-openbao` sidecar →
+OpenBao's Service) — the same address `11-secrets/openbao/{bootstrap,managed}`
+now default to (see their `version.tf`/`variables.tf`).
 
 ## Why its own domain, and why it's temporary
 

--- a/04-vpn/wireguard-site-to-site/main.tf
+++ b/04-vpn/wireguard-site-to-site/main.tf
@@ -26,11 +26,15 @@ data "wireguard_config_document" "peer" {
   private_key = wireguard_asymmetric_key.peer[each.key].private_key
   addresses   = [each.value.address]
   # Split DNS: the tunnel server's own `dns` sidecar (gitops repo's
-  # services/platform/wireguard/config) answers *.scalepack.fr with its own
-  # tunnel address while forwarding everything else upstream — so every
-  # OIDC-gated app (Grafana, ArgoCD, ...) works over the tunnel using its
-  # real hostname, scoped to exactly this interface's lifetime (nothing to
-  # revert when the tunnel goes down, unlike an /etc/hosts edit).
+  # services/platform/wireguard-site-to-site/config, dnsInternalZones) answers
+  # internal-cluster hostnames (the "svc" / "cluster.local" suffixes — any
+  # Service in any namespace, e.g. openbao.openbao.svc.cluster.local) with
+  # its own tunnel address while forwarding everything else upstream — so a
+  # peer reaches any internal address using its real Service hostname,
+  # scoped to exactly this interface's lifetime (nothing to revert when the
+  # tunnel goes down, unlike an /etc/hosts edit). Resolving the name only
+  # gets a peer to the tunnel pod — that chart's proxyTargets is what
+  # actually forwards the traffic on to the real Service (infrastructure#81).
   dns = [split("/", var.server_address)[0]]
 
   peer {

--- a/11-secrets/openbao/bootstrap/version.tf
+++ b/11-secrets/openbao/bootstrap/version.tf
@@ -40,10 +40,16 @@ terraform {
 # session doesn't populate the env var this hashicorp/vault provider expects.
 # Only the token stays in the environment — see README.
 provider "vault" {
-  # Same hostname as the public route, resolved through the WireGuard
-  # tunnel via split-DNS while it's up — see
-  # 11-secrets/openbao/managed/version.tf's comment for the full rationale.
-  address = "https://openbao.scalepack.fr/"
+  # Same internal Service address Argo Workflows already uses in-cluster
+  # (gitops repo's services/platform/argo-workflows), reachable here through
+  # the WireGuard tunnel's internal-cluster DNS + proxyTargets (04-vpn/
+  # wireguard-site-to-site/README.md's "Internal cluster DNS" section,
+  # infrastructure#81) — bring the tunnel up first (`wg-quick up
+  # <peer_conf_paths output>`). No -var override exists for this root (it
+  # only ever runs admin-applied locally, never in CI or in-cluster, unlike
+  # 11-secrets/openbao/managed's var.vault_address), so this is hardcoded
+  # the same way the previous public-route default was.
+  address = "http://openbao.openbao.svc:8200/"
   # address = "http://127.0.0.1:8200/"  # kubectl port-forward, independent of the tunnel
   # token = var.root_token
 }

--- a/11-secrets/openbao/managed/variables.tf
+++ b/11-secrets/openbao/managed/variables.tf
@@ -56,12 +56,12 @@ variable "secrets_sync_github" {
 }
 
 # See version.tf's provider "vault" block for the three real addresses this
-# resolves to (public route / in-cluster Service / port-forward) and which
+# resolves to (in-cluster Service / port-forward / public route) and which
 # execution context uses each.
 variable "vault_address" {
   description = "Address the vault provider authenticates against."
   type        = string
-  default     = "https://openbao.scalepack.fr/"
+  default     = "http://openbao.openbao.svc:8200/"
 }
 
 # ── Cross-root state reads (Scaleway state buckets, see 00-foundation/scaleway) ──

--- a/11-secrets/openbao/managed/version.tf
+++ b/11-secrets/openbao/managed/version.tf
@@ -64,26 +64,27 @@ data "terraform_remote_state" "openbao_bootstrap" {
 # not Vault's VAULT_ADDR/VAULT_TOKEN, so relying on the env var is a trap (see
 # the bootstrap root's version.tf/README for the incident this came from).
 provider "vault" {
-  # Defaults to OpenBao's public route — same hostname whether or not the
-  # WireGuard tunnel is up, on purpose: split-DNS (the tunnel's dns
-  # sidecar, gitops repo's services/platform/wireguard/config) resolves
-  # this to the tunnel's own address (04-vpn/wireguard) while it's up,
-  # routing privately through Envoy Gateway's real Service (proxy-gateway
-  # sidecar) instead of the public internet. Same address either way —
-  # bring the tunnel up first (`wg-quick up <peer_conf_paths output>`), or
-  # this just hits the real public route (fine; that's still there for
-  # human OIDC/UI login, this provider just doesn't need it anymore).
+  # Defaults to the same internal Service address Argo Workflows already
+  # uses in-cluster (http://openbao.openbao.svc:8200, matches
+  # services/platform/openbao/init's baoAddr) — since infrastructure#81,
+  # reachable here too through the WireGuard tunnel's internal-cluster DNS +
+  # proxyTargets (04-vpn/wireguard-site-to-site/README.md's "Internal
+  # cluster DNS" section) instead of the public route. Bring the tunnel up
+  # first (`wg-quick up <peer_conf_paths output>`).
   #
   # Overridden via -var for the two other real execution contexts this root
   # runs in: the Argo Workflows CronWorkflow (gitops repo
-  # services/platform/argo-workflows) passes the in-cluster Service address
-  # (http://openbao.openbao.svc:8200, matches services/platform/openbao/
-  # init's baoAddr) — the whole reason that CronWorkflow exists is OpenBao
-  # not being reachable from outside the cluster for a while after boot, so
-  # it never needs the tunnel/public-route dance below. A direct port-
-  # forward (`kubectl port-forward -n openbao openbao-0 8200:8200`,
-  # requires Kubernetes permissions) is the third: -var
-  # vault_address=http://127.0.0.1:8200/.
+  # services/platform/argo-workflows) passes this same address directly
+  # (-var vault_address=http://openbao.openbao.svc:8200/ — redundant with
+  # the default now, kept explicit in that chart's values since it's the
+  # whole reason that CronWorkflow exists: OpenBao not being reachable from
+  # outside the cluster for a while after boot, so it can't depend on this
+  # default ever changing back). A direct port-forward (`kubectl
+  # port-forward -n openbao openbao-0 8200:8200`, requires Kubernetes
+  # permissions) is the third, for when the tunnel itself is the thing
+  # being debugged: -var vault_address=http://127.0.0.1:8200/. The public
+  # route (https://openbao.scalepack.fr/) still works too — that's still
+  # there for human OIDC/UI login — just isn't the default anymore.
   address = var.vault_address
 
   # address = "http://127.0.0.1:8200"


### PR DESCRIPTION
## Summary
Part of infrastructure#81 — volet 2 (infra side). Depends on the companion gitops PR for the actual DNS/proxy mechanism to exist in-cluster.

- `04-vpn/wireguard-site-to-site`: updated comments (main.tf, README.md) to describe the generalized internal-cluster DNS resolution (`dnsInternalZones` + `proxyTargets`) implemented in the companion gitops PR, replacing the old `*.scalepack.fr`-only split-DNS. No Terraform resource changes — this root's actual keys/config are untouched.
- `11-secrets/openbao/bootstrap`: `vault` provider address now defaults to `http://openbao.openbao.svc:8200/` (same address Argo Workflows already uses in-cluster) instead of the public route `https://openbao.scalepack.fr/`.
- `11-secrets/openbao/managed`: `var.vault_address` default changed the same way.
- The commented `kubectl port-forward` bypass snippets are kept unchanged in both roots, as requested.
- Checked `12-monitoring/grafana/{bootstrap,managed}`: does **not** need the same change — its `grafana_url` default is intentionally public (basic-auth admin path bypasses the SSO edge policy, no tunnel dependency, see that root's own comment) unlike OpenBao's OIDC-gated vault provider path.

## Not done yet (needs the tunnel up + gitops PR merged first)
- Live validation (`dig`/`curl` an internal address over the tunnel).
- Real `terraform plan`/`apply` against these roots on the new default address.

No `terraform apply` was run as part of this PR — asked before doing so per repo convention.

## Test plan
- [x] `terraform validate` + `terraform fmt -check` on `04-vpn/wireguard-site-to-site`, `11-secrets/openbao/bootstrap`, `11-secrets/openbao/managed`
- [ ] Bring up the WireGuard tunnel, `dig openbao.openbao.svc.cluster.local` resolves to the tunnel address
- [ ] `curl http://openbao.openbao.svc.cluster.local:8200/v1/sys/health` reaches OpenBao over the tunnel
- [ ] `terraform plan` (then `apply`, with explicit go-ahead) against `11-secrets/openbao/{bootstrap,managed}` with the tunnel up

Companion PR: IntegratedDynamic/gitops#46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEQvH4yQbbKCrmTZzDSz4P