### PR TITLE
feat(monitoring): default Grafana roots to internal cluster DNS over the tunnel

### DIFF
--- a/04-vpn/wireguard-site-to-site/README.md
+++ b/04-vpn/wireguard-site-to-site/README.md
@@ -102,15 +102,34 @@ Kapsule's kubelet doesn't allowlist that sysctl, and Scaleway's
 version at all. Even where available, that's a cluster-wide relaxation for
 one workload's benefit — worth avoiding regardless.
 
-The gitops chart instead terminates the tunnel and proxies to each target
-at the application layer (`proxyTargets`, one `socat` sidecar per entry,
-resolving its target — e.g. `openbao.openbao.svc.cluster.local` — via
-ordinary in-cluster DNS) — no kernel routing, no sysctls, no dependency on
-any `ClusterIP` being stable across a cluster rebuild. This is also why DNS
-resolution alone (see "Internal cluster DNS" below) doesn't make an
-*arbitrary* internal address reachable: a peer's traffic still needs a
-listener on the tunnel pod for the specific target port, so a new address
-means adding a `proxyTargets` entry, not just a DNS answer.
+The gitops chart instead terminates the tunnel and proxies at the
+application layer: no kernel routing, no sysctls, no dependency on any
+`ClusterIP` being stable across a cluster rebuild. A first pass at this
+(infrastructure#81's initial PR, 2026-08-24) used one `socat` sidecar per
+named target (`proxyTargets: {name: {port, target}}`) — simple, but meant
+listing every internal Service by hand, one PR per addition. Replaced the
+same day with `proxy-dynamic` (gitops repo's `services/platform/
+wireguard-site-to-site/config`, `dynamicProxy`): a single `nginx` sidecar
+that resolves the *actual* backend live from what the peer's own request
+names — the plain-HTTP request's `Host` header (`dynamicProxy.httpPorts`)
+or the TLS ClientHello's SNI (`dynamicProxy.tlsPorts`, passthrough via
+`ssl_preread`, no certificate needed) — against this cluster's own CoreDNS,
+instead of a hardcoded target. Any internal Service on an already-listened
+port is reachable the moment DNS resolves its name (see "Internal cluster
+DNS" below); nothing to add to the gitops chart when a new one shows up.
+
+A TCP listener still has to be bound per **port** ahead of time (a socket
+can't cover every port at once) — that's the one thing not fully dynamic.
+`dynamicProxy.httpPorts` covers OpenBao's plain-HTTP API (`8200`) and
+Grafana (`80`) today; add a port there (not a target) the day some other
+internal service needs one neither already covers.
+
+**Verified live 2026-08-24** (a debug pod running the exact rendered
+`nginx.conf`, `nginx -t` plus a real request): `curl` with `Host:
+openbao.openbao.svc.cluster.local:8200` returns OpenBao's real
+`/v1/sys/health`, and `Host: grafana.monitoring.svc.cluster.local` against
+port `80` returns Grafana's normal 302 — both driven purely by the Host
+header, no target hardcoded anywhere in the proxy.
 
 ## Internal cluster DNS
 
@@ -127,12 +146,11 @@ passthrough to Envoy Gateway, for OIDC-gated web UIs) were removed
 reaching an internal API, not human OIDC/UI login, which stays on the
 public route untouched.
 
-With the tunnel up, `dig openbao.openbao.svc.cluster.local` should resolve
-to the tunnel's own address and `curl
-http://openbao.openbao.svc.cluster.local:8200/v1/sys/health` should reach
-OpenBao through the full chain (tunnel → gitops's `proxy-openbao` sidecar →
-OpenBao's Service) — the same address `11-secrets/openbao/{bootstrap,managed}`
-now default to (see their `version.tf`/`variables.tf`).
+`11-secrets/openbao/{bootstrap,managed}` default to
+`http://openbao.openbao.svc:8200/` and `12-monitoring/grafana/
+{bootstrap,managed}` to `http://grafana.monitoring.svc:80/` — both reach
+their target through `proxy-dynamic` above once the tunnel is up (see each
+root's own `version.tf`/`variables.tf`).
 
 ## Why its own domain, and why it's temporary
 

--- a/04-vpn/wireguard-site-to-site/main.tf
+++ b/04-vpn/wireguard-site-to-site/main.tf
@@ -33,8 +33,9 @@ data "wireguard_config_document" "peer" {
   # peer reaches any internal address using its real Service hostname,
   # scoped to exactly this interface's lifetime (nothing to revert when the
   # tunnel goes down, unlike an /etc/hosts edit). Resolving the name only
-  # gets a peer to the tunnel pod — that chart's proxyTargets is what
-  # actually forwards the traffic on to the real Service (infrastructure#81).
+  # gets a peer to the tunnel pod — that chart's proxy-dynamic sidecar is
+  # what actually forwards the traffic on to the real Service, resolved
+  # live from the request's own Host header/SNI (infrastructure#81).
   dns = [split("/", var.server_address)[0]]
 
   peer {

--- a/11-secrets/openbao/bootstrap/version.tf
+++ b/11-secrets/openbao/bootstrap/version.tf
@@ -42,8 +42,8 @@ terraform {
 provider "vault" {
   # Same internal Service address Argo Workflows already uses in-cluster
   # (gitops repo's services/platform/argo-workflows), reachable here through
-  # the WireGuard tunnel's internal-cluster DNS + proxyTargets (04-vpn/
-  # wireguard-site-to-site/README.md's "Internal cluster DNS" section,
+  # the WireGuard tunnel's internal-cluster DNS + proxy-dynamic sidecar
+  # (04-vpn/wireguard-site-to-site/README.md's "Internal cluster DNS" section,
   # infrastructure#81) — bring the tunnel up first (`wg-quick up
   # <peer_conf_paths output>`). No -var override exists for this root (it
   # only ever runs admin-applied locally, never in CI or in-cluster, unlike

--- a/11-secrets/openbao/managed/version.tf
+++ b/11-secrets/openbao/managed/version.tf
@@ -68,8 +68,8 @@ provider "vault" {
   # uses in-cluster (http://openbao.openbao.svc:8200, matches
   # services/platform/openbao/init's baoAddr) — since infrastructure#81,
   # reachable here too through the WireGuard tunnel's internal-cluster DNS +
-  # proxyTargets (04-vpn/wireguard-site-to-site/README.md's "Internal
-  # cluster DNS" section) instead of the public route. Bring the tunnel up
+  # proxy-dynamic sidecar (04-vpn/wireguard-site-to-site/README.md's
+  # "Internal cluster DNS" section) instead of the public route. Bring the tunnel up
   # first (`wg-quick up <peer_conf_paths output>`).
   #
   # Overridden via -var for the two other real execution contexts this root

--- a/12-monitoring/grafana/bootstrap/README.md
+++ b/12-monitoring/grafana/bootstrap/README.md
@@ -48,11 +48,16 @@ Terraform-managed by `11-secrets/openbao/managed`
 
 - **`grafana` provider**: authenticates as Grafana's admin via basic auth
   (`"admin:${password}"`), password read straight from
-  `11-secrets/openbao/managed`'s state — see `version.tf`. Public route
-  (`https://grafana.scalepack.fr/`): Grafana's basic-auth API path isn't
-  gated behind the shared sso-guard edge policy (gitops repo's
-  `services/platform/monitoring/grafana-gateway` deliberately bypasses it,
-  same as OpenBao's own public route), so no WireGuard tunnel is needed.
+  `11-secrets/openbao/managed`'s state — see `version.tf`. Defaults to
+  Grafana's internal Service address (`http://grafana.monitoring.svc:80/`),
+  reachable via the WireGuard tunnel's internal-cluster DNS + proxy-dynamic
+  sidecar (`04-vpn/wireguard-site-to-site/README.md`, infrastructure#81) — same
+  pattern as the `vault` provider's own default. The public route
+  (`https://grafana.scalepack.fr/`) still works too if the tunnel isn't up:
+  Grafana's basic-auth API path isn't gated behind the shared sso-guard edge
+  policy (gitops repo's `services/platform/monitoring/grafana-gateway`
+  deliberately bypasses it), same as OpenBao's own public route — just
+  isn't the default anymore.
 - **S3 state backend**: same AWS-style env vars as every other root (via
   `mise.toml`'s `[env]` block).
 

--- a/12-monitoring/grafana/bootstrap/variables.tf
+++ b/12-monitoring/grafana/bootstrap/variables.tf
@@ -24,5 +24,5 @@ variable "openbao_managed_state_key" {
 variable "grafana_url" {
   description = "URL the grafana provider authenticates against."
   type        = string
-  default     = "https://grafana.scalepack.fr/"
+  default     = "http://grafana.monitoring.svc:80/"
 }

--- a/12-monitoring/grafana/bootstrap/version.tf
+++ b/12-monitoring/grafana/bootstrap/version.tf
@@ -101,20 +101,31 @@ data "terraform_remote_state" "openbao_managed" {
 # credential 11-secrets/openbao/managed already generates and owns
 # (kv/apps/grafana/admin). No chicken-and-egg like OpenBao's own bootstrap
 # root_token: Grafana's admin password is already Terraform state elsewhere,
-# so this root needs zero manually-supplied secrets. Defaults to the public
-# route: Grafana's basic-auth API path isn't gated behind the shared
-# sso-guard edge policy (gitops repo's services/platform/monitoring/
-# grafana-gateway deliberately bypasses it, same reasoning the OpenBao
-# vault provider's own comment gives for its public route), so no
-# WireGuard tunnel is needed for the admin path.
+# so this root needs zero manually-supplied secrets.
 #
-# Overridden via -var for the Argo Workflows CronWorkflow: confirmed live,
-# the public route consistently times out ("context deadline exceeded")
-# from inside the cluster -- pods reaching the cluster's own public
-# ingress from behind it is a common hairpin-NAT gap, not something this
-# root can fix. -var grafana_url=http://grafana.monitoring.svc:80/
-# (matches gitops repo's services/platform/monitoring/grafana-gateway's
-# backend Service) avoids the public route entirely for that context.
+# Defaults to Grafana's internal Service address (matches gitops repo's
+# services/platform/monitoring's Grafana Service, namespace monitoring, port
+# 80) — since infrastructure#81, reachable here through the WireGuard
+# tunnel's internal-cluster DNS + proxy-dynamic sidecar (04-vpn/wireguard-
+# site-to-site/README.md's "Internal cluster DNS" section), same pattern as the
+# vault provider's own default in 11-secrets/openbao/{bootstrap,managed}.
+# Bring the tunnel up first (`wg-quick up <peer_conf_paths output>`).
+#
+# Grafana's basic-auth API path specifically isn't gated behind the shared
+# sso-guard edge policy (gitops repo's services/platform/monitoring/
+# grafana-gateway deliberately bypasses it), so the public route
+# (https://grafana.scalepack.fr/) still works fine too if the tunnel isn't
+# up — just isn't the default anymore, for consistency with the vault
+# provider's own address.
+#
+# Overridden via -var for the Argo Workflows CronWorkflow (gitops repo
+# services/platform/argo-workflows) — passes this same address directly,
+# redundant with the default now, kept explicit in that chart's values
+# since it's the whole reason the override exists: confirmed live, the
+# public route consistently times out ("context deadline exceeded") from
+# inside the cluster (a pod reaching the cluster's own public ingress from
+# behind it is a common hairpin-NAT gap), so it can't depend on this
+# default ever changing back.
 provider "grafana" {
   url  = var.grafana_url
   auth = "admin:${data.terraform_remote_state.openbao_managed.outputs.grafana_admin_password}"

--- a/12-monitoring/grafana/managed/README.md
+++ b/12-monitoring/grafana/managed/README.md
@@ -42,7 +42,9 @@ grows beyond one personal-use token.
 
 - **`grafana` provider**: authenticates as the `terraform` service account
   from `12-monitoring/grafana/bootstrap`, read via
-  `data.terraform_remote_state` — see `version.tf`.
+  `data.terraform_remote_state` — see `version.tf`. Defaults to Grafana's
+  internal Service address, same address/tunnel rationale as that root's
+  own `version.tf` (infrastructure#81).
 - **`vault` provider**: reuses the same `terraform` AppRole
   `11-secrets/openbao/managed` itself authenticates as (its policy already
   grants `kv/data|metadata/apps/*` broadly, so writing a new path here needs

--- a/12-monitoring/grafana/managed/variables.tf
+++ b/12-monitoring/grafana/managed/variables.tf
@@ -22,5 +22,5 @@ variable "grafana_bootstrap_state_key" {
 variable "grafana_url" {
   description = "URL the grafana provider authenticates against."
   type        = string
-  default     = "https://grafana.scalepack.fr/"
+  default     = "http://grafana.monitoring.svc:80/"
 }


### PR DESCRIPTION
## Summary
Follow-up to infrastructure#81 — same treatment applied to Grafana as OpenBao. Documentation-only in this repo; the actual mechanism change is in the companion gitops PR.

- `12-monitoring/grafana/bootstrap`: `grafana` provider now defaults to `http://grafana.monitoring.svc:80/` instead of the public route `https://grafana.scalepack.fr/`.
- `12-monitoring/grafana/managed`: same default change.
- Public route still works as a fallback (Grafana's basic-auth API path bypasses the SSO edge policy, no tunnel dependency) — just isn't the default anymore, for consistency with the OpenBao pattern.
- README/comment updates across `04-vpn/wireguard-site-to-site`, `11-secrets/openbao/{bootstrap,managed}`, and `12-monitoring/grafana/bootstrap` describing the companion PR's redesign: the tunnel's proxy mechanism moved from one hardcoded target per service (`proxyTargets`, infra#81's first PR) to a single discovery-based `proxy-dynamic` sidecar that resolves the backend live from the request's own Host header/SNI — see `04-vpn/wireguard-site-to-site/README.md`'s "Why the tunnel doesn't route to internal ClusterIPs directly" for the full design and the live verification that was done before it got documented.
- Addresses themselves (`http://openbao.openbao.svc:8200/`, `http://grafana.monitoring.svc:80/`) are unchanged by this — the mechanism change is transparent to callers.

Noted in passing, not touched (out of scope): `12-monitoring/grafana/managed/README.md`'s Credentials section has a stale bullet describing a `vault` provider this root doesn't actually declare (only `grafana`/`external` in `required_providers`) — pre-existing, unrelated to this change.

## Test plan
- [x] `terraform validate` + `terraform fmt -check` on the files I touched in both grafana roots
- [ ] With the tunnel up (and companion gitops PR merged), `terraform plan` against `12-monitoring/grafana/{bootstrap,managed}` with the new default address

No `terraform apply` run as part of this PR.

Companion PR: IntegratedDynamic/gitops#47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEQvH4yQbbKCrmTZzDSz4P