### PR TITLE
feat: extract secrets/monitoring/backups from gitops, launched in parallel ahead of bootstrap

### DIFF
--- a/10-cluster/scaleway/.terraform.lock.hcl
+++ b/10-cluster/scaleway/.terraform.lock.hcl
@@ -1,29 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version = "6.61.0"
-  hashes = [
-    "h1:luPmlKygfw2SMKJkMQ++/J8rRR0ZgR0uJPupp8wy3pw=",
-    "zh:216566f0fbc506e107d3a961c87d88aed052ec2b4ced13388394d3cff30425ac",
-    "zh:4700ad141d0ad96465ac35a3900f2ff7c91a1e5528428ac687c8b5825c0be718",
-    "zh:6b79d2fa6550fc51e2fac04f1066c5cc96e957e7634ad86d2250240e637db205",
-    "zh:76f6227bf2bcd7422cf29d9868d8b517c8220ec3edd4e7c8434b867a71c03334",
-    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a7be5814cf94a8e3869ec9fa7f5182223a11373a4510ce68b9bab431f9b83746",
-    "zh:b65392e24506fe99f8df7bd2b5d3940d7a234b64b79a890f1aabe2be91a827e5",
-    "zh:b68a5092203cf5a9d1a5f01f9f2e96fded3eb7cacfd49ae851c50b87bc610fe9",
-    "zh:b8fedfa62bac16592519e1bae0c82dd7cd1544b0637543d72e3597e46ad7db32",
-    "zh:bba8a35212c07e68b6c881aa011c4b26a284e42b971059579aca9ffb63a8faef",
-    "zh:bbd0391e3e2f21c8930872829df7cf7f4e35f84c4d6d7b7619a94f8078fe6f3d",
-    "zh:c9c921e8e466281c04cada8d336ec1ce978128ee153e9df7b451847fbea49d18",
-    "zh:c9cb0be3097f4392b977fa254d28efd0909d008f572e74a41ead6c0d84c0daaa",
-    "zh:cc7aeb23fa3775816e391d4668a9865f787993f9f8d6f5b7a9f7e4effdffb3cb",
-    "zh:e59e487220cec8999bbd120ba8f97b5e04b010fb9149e47d4c9032961614d7c7",
-    "zh:fa19a7571a99397120f2f2bdcf33bbcc2f39091b9b0c879cd7e5f9ebb1966c40",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/external" {
   version     = "2.4.1"
   constraints = "~> 2.0"

--- a/10-cluster/scaleway/.terraform.lock.hcl
+++ b/10-cluster/scaleway/.terraform.lock.hcl
@@ -66,28 +66,6 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/local" {
-  version     = "2.9.0"
-  constraints = "~> 2.0"
-  hashes = [
-    "h1:9rBZCMNpxKwMlRbWH2QpwD3kqUCAejdOZQ/aiiDObXQ=",
-    "h1:m24fjcInWvTVZ1XSo2MaNuKPe+X/gfG8SIi09rA7a7M=",
-    "zh:0baa4566cf77f1ff52f4293d1c8536202dd23edc197c3196413a28343c3ac3a0",
-    "zh:16b5559c3c07088ddad11a9bb9e9c0799999363c2958e9a5be2bcbbf2cd9ca64",
-    "zh:197c79015a10d1cce904a8ea722cbc750c42aeae2da53f44a6a0751d9fd1aa90",
-    "zh:29d0b03e5343a80677ebfeb2e2c31cbe4b1f65e736e53417454a4277fec2544c",
-    "zh:4896bfa6cf1d2fd562b47ef2e87f47862ae92a04f8ad5d764380f0c6653473b8",
-    "zh:531f8529cbca49f681883e57761a05a8398afaef6d1ab0d205d26bf12f4428e8",
-    "zh:6aaf5011d83161c86d2bfb80c0923ec934e578288758da2f37acb7aec129004b",
-    "zh:7430275253d3d3c40aa6179e0ec0d63212874dbbc06c5a51b9d07ec590f9756c",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:be17dc611e95e26cdf6cad79dfccf1064f0e32032a2efeb939a9bbe7fb1cbfe9",
-    "zh:f0e3b0aa644202e1d79d2000dca91f6019425da71e9800fa23f27e51c034f195",
-    "zh:f62bae4519e4ead49182ddc8afe8cf61e2a4c3ba3973b0fbba967736a2696aa3",
-    "zh:fcafa360a5b0b96244f26f4e3a6d642b716a376557142c2442ff2fb12d11da18",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.3.1"
   constraints = "~> 3.0"

--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -581,8 +581,13 @@ resource "kubernetes_job_v1" "wait_platform_apps_healthy" {
   spec {
     # Overall budget for all four Applications combined — generous for the
     # same "cluster boot, not steady-state" reason bootstrap's own
-    # syncPolicy.retry.limit comment gives.
-    active_deadline_seconds = 900
+    # syncPolicy.retry.limit comment gives. Bumped 900 -> 1800 (2026-08-25):
+    # confirmed live on a from-scratch cluster boot that a healthy run can
+    # itself take 7+ minutes once ArgoCD/DNS warm-up variance is factored
+    # in, and the first-ever timing run hit the original 900s budget
+    # outright -- 1800s is a deliberately generous placeholder until this
+    # is measured more precisely across a few more boots.
+    active_deadline_seconds = 1800
     backoff_limit           = 0
 
     template {
@@ -640,8 +645,12 @@ resource "kubernetes_job_v1" "wait_platform_apps_healthy" {
 
   wait_for_completion = true
 
+  # Must stay above active_deadline_seconds above (30m) -- this is
+  # Terraform's own wait on the Job resource itself, so a shorter value
+  # here would make Terraform give up before the Job's own budget even
+  # runs out.
   timeouts {
-    create = "16m"
+    create = "35m"
   }
 
   depends_on = [

--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -340,7 +340,11 @@ resource "helm_release" "argocd_apps" {
   chart      = "argocd-apps"
   version    = "2.0.4"
 
-  depends_on = [helm_release.argocd]
+  # wait_platform_apps_healthy (below) is the real Terraform-enforced
+  # prerequisite: bootstrap's Application must not even be created until
+  # secrets-apps/monitoring-apps/backups-apps are Healthy — see
+  # platform-apps/README.md.
+  depends_on = [helm_release.argocd, null_resource.wait_platform_apps_healthy]
 
   values = [<<EOF
 applications:
@@ -365,8 +369,8 @@ applications:
 
     syncPolicy:
       # Since this application bootstrap all the gitops repo, it's equal to cluster startup duration, which is greated than default argocd timeout values.
-      retry: 
-        limit: 10 
+      retry:
+        limit: 10
       automated:
         prune: true
         selfHeal: true
@@ -374,4 +378,184 @@ applications:
         - CreateNamespace=true
 EOF
   ]
+}
+
+# ── Secrets/monitoring/backups, extracted from gitops repo (infra#84) ───────
+#
+# Three parent Applications (secrets-apps/monitoring-apps/backups-apps),
+# each pointing at this repo's own platform-apps/ chart (not gitops) for
+# their OWN list of child Applications — see that chart's README.md for the
+# full "why" (ArgoCD sync-wave only orders resources within one parent
+# Application's own sync, so three separate parents is what actually lets
+# these domains start in parallel with each other while keeping each
+# domain's own real intra-domain ordering, e.g. kube-prometheus-stack-crds
+# before kube-prometheus-stack). The child Applications' own charts
+# (services/platform/openbao/chart, monitoring/chart, ...) are untouched,
+# still pulled from the gitops repo, same as before this split — only which
+# parent Application claims them as managed resources changed.
+resource "helm_release" "argocd_platform_apps" {
+  name      = "argocd-platform-apps"
+  namespace = "argocd"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.4"
+
+  depends_on = [
+    helm_release.argocd,
+    kubernetes_secret.thanos_objstore_config,
+    kubernetes_secret.loki_s3_credentials,
+    kubernetes_secret.tempo_s3_credentials,
+    kubernetes_secret.velero_scaleway_credentials,
+  ]
+
+  values = [<<EOF
+applications:
+  secrets-apps:
+    namespace: argocd
+    project: default
+    source:
+      repoURL: https://github.com/IntegratedDynamic/infrastructure.git
+      targetRevision: ${var.infra_revision}
+      path: 10-cluster/scaleway/platform-apps
+      helm:
+        valueFiles:
+          - values-secrets.yaml
+        parameters:
+          - name: revision
+            value: ${var.gitops_revision}
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: argocd
+    syncPolicy:
+      retry:
+        limit: 10
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+
+  monitoring-apps:
+    namespace: argocd
+    project: default
+    source:
+      repoURL: https://github.com/IntegratedDynamic/infrastructure.git
+      targetRevision: ${var.infra_revision}
+      path: 10-cluster/scaleway/platform-apps
+      helm:
+        valueFiles:
+          - values-monitoring.yaml
+        parameters:
+          - name: revision
+            value: ${var.gitops_revision}
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: argocd
+    syncPolicy:
+      retry:
+        limit: 10
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+
+  backups-apps:
+    namespace: argocd
+    project: default
+    source:
+      repoURL: https://github.com/IntegratedDynamic/infrastructure.git
+      targetRevision: ${var.infra_revision}
+      path: 10-cluster/scaleway/platform-apps
+      helm:
+        valueFiles:
+          - values-backups.yaml
+        parameters:
+          - name: revision
+            value: ${var.gitops_revision}
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: argocd
+    syncPolicy:
+      retry:
+        limit: 10
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+EOF
+  ]
+}
+
+# Self-contained kubeconfig for the health-wait below — deliberately NOT the
+# ~/.kube/config context null_resource.update_kubeconfig (main.tf) manages,
+# since that resource is opt-in (var.update_kubeconfig, "mainly for local
+# debugging") and this wait must work unconditionally, in CI or locally.
+resource "local_sensitive_file" "platform_apps_wait_kubeconfig" {
+  filename = "${path.module}/.terraform/tmp-platform-apps-wait-kubeconfig.yaml"
+
+  content = <<-EOT
+    apiVersion: v1
+    kind: Config
+    clusters:
+      - name: wait-cluster
+        cluster:
+          server: ${scaleway_k8s_cluster.this.kubeconfig[0].host}
+          certificate-authority-data: ${scaleway_k8s_cluster.this.kubeconfig[0].cluster_ca_certificate}
+    contexts:
+      - name: wait-context
+        context:
+          cluster: wait-cluster
+          user: wait-user
+    current-context: wait-context
+    users:
+      - name: wait-user
+        user:
+          token: ${scaleway_k8s_cluster.this.kubeconfig[0].token}
+  EOT
+
+  file_permission = "0600"
+}
+
+# The Terraform-enforced prerequisite itself: secrets-apps/monitoring-apps/
+# backups-apps must all reach Healthy before bootstrap's own Application
+# resource is even created (see that resource's depends_on above) — ArgoCD
+# has no native way to express "wait for these independent top-level
+# Applications" (sync-wave doesn't cross Application boundaries), so this is
+# enforced as a real Terraform apply-order dependency instead. Polls rather
+# than a single `kubectl wait --for=jsonpath=...`, since that fails
+# immediately (not "waits") when `.status.health` doesn't exist yet at all —
+# which is true for the first several seconds of a brand new Application.
+resource "null_resource" "wait_platform_apps_healthy" {
+  depends_on = [helm_release.argocd_platform_apps]
+
+  triggers = {
+    # Re-run the wait whenever the platform apps are re-applied.
+    platform_apps = helm_release.argocd_platform_apps.metadata.revision
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -eu
+      export KUBECONFIG=${local_sensitive_file.platform_apps_wait_kubeconfig.filename}
+      for app in secrets-apps monitoring-apps backups-apps; do
+        echo "Waiting for Application/$app to become Healthy..."
+        deadline=$(($(date +%s) + 600))
+        while true; do
+          status=$(kubectl get application "$app" -n argocd -o jsonpath='{.status.health.status}' 2>/dev/null || true)
+          if [ "$status" = "Healthy" ]; then
+            echo "Application/$app is Healthy."
+            break
+          fi
+          if [ "$(date +%s)" -ge "$deadline" ]; then
+            echo "Timed out waiting for Application/$app to become Healthy (last status: '$status')." >&2
+            exit 1
+          fi
+          sleep 5
+        done
+      done
+    EOT
+  }
 }

--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -340,6 +340,15 @@ resource "helm_release" "argocd_apps" {
   chart      = "argocd-apps"
   version    = "2.0.4"
 
+  # Applies to both install AND uninstall (the provider uses the same
+  # timeout for whichever Helm operation this resource is currently
+  # performing) -- default (300s) isn't enough for uninstall since
+  # bootstrap's own resources-finalizer.argocd.argoproj.io (see values
+  # below) now makes its deletion wait for ArgoCD to cascade-delete its
+  # entire child-Application tree first, confirmed live (2026-08-25) to
+  # exceed 5 minutes.
+  timeout = 1800
+
   # wait_platform_apps_healthy (below) is the real Terraform-enforced
   # prerequisite: bootstrap's Application must not even be created until
   # secrets-apps/monitoring-apps/backups-apps/networking-apps are Healthy —
@@ -414,6 +423,15 @@ resource "helm_release" "argocd_platform_apps" {
   repository = "https://argoproj.github.io/argo-helm"
   chart      = "argocd-apps"
   version    = "2.0.4"
+
+  # Applies to both install AND uninstall -- default (300s) isn't enough
+  # for uninstall, since each domain's own resources-finalizer.argocd.argoproj.io
+  # (see values below) now makes deleting these four Applications wait for
+  # ArgoCD to cascade-delete their entire child-Application trees first.
+  # Same timeout as kubernetes_job_v1.wait_platform_apps_healthy's own
+  # budget (below) -- confirmed live (2026-08-25) that this exceeded 5
+  # minutes and made this resource's own destroy time out.
+  timeout = 1800
 
   depends_on = [
     helm_release.argocd,

--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -433,8 +433,21 @@ resource "helm_release" "argocd_platform_apps" {
   # minutes and made this resource's own destroy time out.
   timeout = 1800
 
+  # scaleway_s3_credentials/openbao_unseal_aws included here too (not just
+  # the four secrets this split introduced): without them, nothing ordered
+  # kubernetes_namespace.openbao's destroy after this release's own --
+  # confirmed live (2026-08-25) that ArgoCD's openbao Application (with
+  # selfHeal: true, and now resources-finalizer.argocd.argoproj.io) was
+  # still actively retrying "create content in namespace openbao" while
+  # Terraform was independently, concurrently deleting that same namespace
+  # directly -- every retry failing with "namespace is being terminated",
+  # forever, since nothing told ArgoCD's own graceful teardown to finish
+  # first. monitoring/velero's namespaces never had this problem only by
+  # accident, via their own four secrets already being listed here.
   depends_on = [
     helm_release.argocd,
+    kubernetes_secret.scaleway_s3_credentials,
+    kubernetes_secret.openbao_unseal_aws,
     kubernetes_secret.thanos_objstore_config,
     kubernetes_secret.loki_s3_credentials,
     kubernetes_secret.tempo_s3_credentials,

--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -350,6 +350,19 @@ resource "helm_release" "argocd_apps" {
 applications:
   bootstrap:
     namespace: argocd
+    # Cascade-deletes this Application's own managed resources (its child
+    # Applications' Application CRs, one level of the app-of-apps tree)
+    # before removing this object itself, instead of the default "just
+    # forget about it, leave whatever it deployed running" behavior.
+    # Confirmed live (2026-08-25): without this, a `terraform destroy`
+    # tears down helm_release.argocd_apps/argocd_platform_apps/argocd in
+    # ~13s combined -- nowhere near enough for anything to gracefully
+    # shut down -- leaving e.g. Velero's own pod orphaned right before
+    # kubernetes_namespace.velero's cascade delete races its controller's
+    # own teardown for the Restore CRs' finalizers (see that resource's
+    # own comment in main.tf). https://argo-cd.readthedocs.io/en/stable/user-guide/app_deletion/#about-the-deletion-finalizer
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
     project: default
 
     source:
@@ -414,6 +427,11 @@ resource "helm_release" "argocd_platform_apps" {
 applications:
   secrets-apps:
     namespace: argocd
+    # Cascade-deletes this domain's own child Applications (openbao,
+    # external-secrets, ...) before removing this object -- see
+    # `bootstrap`'s own finalizers comment above for the full "why".
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
     project: default
     source:
       repoURL: https://github.com/IntegratedDynamic/infrastructure.git
@@ -439,6 +457,11 @@ applications:
 
   monitoring-apps:
     namespace: argocd
+    # Cascade-deletes this domain's own child Applications
+    # (kube-prometheus-stack, loki, tempo, ...) before removing this
+    # object -- see `bootstrap`'s own finalizers comment above.
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
     project: default
     source:
       repoURL: https://github.com/IntegratedDynamic/infrastructure.git
@@ -464,6 +487,13 @@ applications:
 
   backups-apps:
     namespace: argocd
+    # Cascade-deletes this domain's own child Application (velero) before
+    # removing this object -- the specific fix for the finalizer race:
+    # gives Velero's own pod a real, ArgoCD-orchestrated shutdown instead
+    # of being torn down by helm_release.argocd's uninstall with no
+    # coordination -- see `bootstrap`'s own finalizers comment above.
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
     project: default
     source:
       repoURL: https://github.com/IntegratedDynamic/infrastructure.git
@@ -489,6 +519,11 @@ applications:
 
   networking-apps:
     namespace: argocd
+    # Cascade-deletes this domain's own child Applications (envoy-gateway,
+    # cert-manager, gateway-config, ...) before removing this object --
+    # see `bootstrap`'s own finalizers comment above.
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
     project: default
     source:
       repoURL: https://github.com/IntegratedDynamic/infrastructure.git

--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -698,14 +698,24 @@ resource "kubernetes_job_v1" "wait_platform_apps_healthy" {
             while true; do
               all_healthy=true
               for app in $apps; do
-                status=$(kubectl get application "$app" -n argocd -o jsonpath='{.status.health.status}' 2>/dev/null || true)
-                if [ "$status" != "Healthy" ]; then
+                sync=$(kubectl get application "$app" -n argocd -o jsonpath='{.status.sync.status}' 2>/dev/null || true)
+                health=$(kubectl get application "$app" -n argocd -o jsonpath='{.status.health.status}' 2>/dev/null || true)
+                # health.status alone isn't enough: a brand-new Application
+                # with zero resources synced yet trivially reports Healthy
+                # (nothing exists yet to BE unhealthy) well before its own
+                # first sync even starts. Confirmed live (2026-08-25): this
+                # Job completed in 17s claiming all four domains healthy,
+                # while backups-apps' own child (velero) hadn't even been
+                # created yet -- checking sync=Synced too is what
+                # wait_bootstrap_healthy already got right below; this Job
+                # just needed the same fix.
+                if [ "$sync" != "Synced" ] || [ "$health" != "Healthy" ]; then
                   all_healthy=false
-                  echo "Application/$app: $${status:-<none yet>}"
+                  echo "Application/$app: sync=$${sync:-<none yet>} health=$${health:-<none yet>}"
                 fi
               done
               if [ "$all_healthy" = "true" ]; then
-                echo "All platform apps are Healthy."
+                echo "All platform apps are Synced and Healthy."
                 exit 0
               fi
               sleep 5

--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -344,7 +344,7 @@ resource "helm_release" "argocd_apps" {
   # prerequisite: bootstrap's Application must not even be created until
   # secrets-apps/monitoring-apps/backups-apps/networking-apps are Healthy —
   # see platform-apps/README.md.
-  depends_on = [helm_release.argocd, null_resource.wait_platform_apps_healthy]
+  depends_on = [helm_release.argocd, kubernetes_job_v1.wait_platform_apps_healthy]
 
   values = [<<EOF
 applications:
@@ -515,74 +515,137 @@ EOF
   ]
 }
 
-# Self-contained kubeconfig for the health-wait below — deliberately NOT the
-# ~/.kube/config context null_resource.update_kubeconfig (main.tf) manages,
-# since that resource is opt-in (var.update_kubeconfig, "mainly for local
-# debugging") and this wait must work unconditionally, in CI or locally.
-resource "local_sensitive_file" "platform_apps_wait_kubeconfig" {
-  filename = "${path.module}/.terraform/tmp-platform-apps-wait-kubeconfig.yaml"
+# RBAC for the health-wait Job below — scoped to exactly what it needs
+# (read-only on Applications in the argocd namespace), nothing broader.
+# Runs as a real in-cluster Job via the Kubernetes API instead of a
+# local-exec provisioner: no dependency on a local `kubectl` binary or a
+# self-generated kubeconfig, works identically whether this root is applied
+# from an admin's machine or CI.
+resource "kubernetes_service_account" "wait_platform_apps" {
+  metadata {
+    name      = "wait-platform-apps-healthy"
+    namespace = "argocd"
+  }
+}
 
-  content = <<-EOT
-    apiVersion: v1
-    kind: Config
-    clusters:
-      - name: wait-cluster
-        cluster:
-          server: ${scaleway_k8s_cluster.this.kubeconfig[0].host}
-          certificate-authority-data: ${scaleway_k8s_cluster.this.kubeconfig[0].cluster_ca_certificate}
-    contexts:
-      - name: wait-context
-        context:
-          cluster: wait-cluster
-          user: wait-user
-    current-context: wait-context
-    users:
-      - name: wait-user
-        user:
-          token: ${scaleway_k8s_cluster.this.kubeconfig[0].token}
-  EOT
+resource "kubernetes_role" "wait_platform_apps" {
+  metadata {
+    name      = "wait-platform-apps-healthy"
+    namespace = "argocd"
+  }
 
-  file_permission = "0600"
+  rule {
+    api_groups = ["argoproj.io"]
+    resources  = ["applications"]
+    verbs      = ["get", "list"]
+  }
+}
+
+resource "kubernetes_role_binding" "wait_platform_apps" {
+  metadata {
+    name      = "wait-platform-apps-healthy"
+    namespace = "argocd"
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role.wait_platform_apps.metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account.wait_platform_apps.metadata[0].name
+    namespace = "argocd"
+  }
 }
 
 # The Terraform-enforced prerequisite itself: secrets-apps/monitoring-apps/
 # backups-apps/networking-apps must all reach Healthy before bootstrap's own
 # Application resource is even created (see that resource's depends_on
-# above) — ArgoCD
-# has no native way to express "wait for these independent top-level
-# Applications" (sync-wave doesn't cross Application boundaries), so this is
-# enforced as a real Terraform apply-order dependency instead. Polls rather
-# than a single `kubectl wait --for=jsonpath=...`, since that fails
-# immediately (not "waits") when `.status.health` doesn't exist yet at all —
-# which is true for the first several seconds of a brand new Application.
-resource "null_resource" "wait_platform_apps_healthy" {
-  depends_on = [helm_release.argocd_platform_apps]
-
-  triggers = {
-    # Re-run the wait whenever the platform apps are re-applied.
-    platform_apps = helm_release.argocd_platform_apps.metadata.revision
+# above) — ArgoCD has no native way to express "wait for these independent
+# top-level Applications" (sync-wave doesn't cross Application boundaries),
+# so this is enforced as a real Terraform apply-order dependency instead.
+# `wait_for_completion` makes Terraform itself block on this Job's Complete
+# condition — no manual polling of the Job from Terraform's side needed.
+# Checks all four Applications together on each iteration (not one at a
+# time with its own budget each) since they sync in parallel — a
+# sequential per-app budget would only be correct if they synced one after
+# another, which is exactly what this whole mechanism exists to avoid.
+resource "kubernetes_job_v1" "wait_platform_apps_healthy" {
+  metadata {
+    name      = "wait-platform-apps-healthy"
+    namespace = "argocd"
   }
 
-  provisioner "local-exec" {
-    command = <<-EOT
-      set -eu
-      export KUBECONFIG=${local_sensitive_file.platform_apps_wait_kubeconfig.filename}
-      for app in secrets-apps monitoring-apps backups-apps networking-apps; do
-        echo "Waiting for Application/$app to become Healthy..."
-        deadline=$(($(date +%s) + 600))
-        while true; do
-          status=$(kubectl get application "$app" -n argocd -o jsonpath='{.status.health.status}' 2>/dev/null || true)
-          if [ "$status" = "Healthy" ]; then
-            echo "Application/$app is Healthy."
-            break
-          fi
-          if [ "$(date +%s)" -ge "$deadline" ]; then
-            echo "Timed out waiting for Application/$app to become Healthy (last status: '$status')." >&2
-            exit 1
-          fi
-          sleep 5
-        done
-      done
-    EOT
+  spec {
+    # Overall budget for all four Applications combined — generous for the
+    # same "cluster boot, not steady-state" reason bootstrap's own
+    # syncPolicy.retry.limit comment gives.
+    active_deadline_seconds = 900
+    backoff_limit           = 0
+
+    template {
+      metadata {
+        labels = {
+          "app.kubernetes.io/name" = "wait-platform-apps-healthy"
+        }
+      }
+
+      spec {
+        service_account_name = kubernetes_service_account.wait_platform_apps.metadata[0].name
+        restart_policy       = "Never"
+
+        container {
+          name = "wait"
+          # Same image gitops repo's services/platform/gateway/config
+          # (cert-restore-job.yaml) already uses for the identical
+          # "kubectl + shell" shape — one fewer image to pull/trust.
+          image = "alpine/kubectl:1.35.3"
+
+          command = ["sh", "-c", <<-EOT
+            set -eu
+            apps="secrets-apps monitoring-apps backups-apps networking-apps"
+            while true; do
+              all_healthy=true
+              for app in $apps; do
+                status=$(kubectl get application "$app" -n argocd -o jsonpath='{.status.health.status}' 2>/dev/null || true)
+                if [ "$status" != "Healthy" ]; then
+                  all_healthy=false
+                  echo "Application/$app: $${status:-<none yet>}"
+                fi
+              done
+              if [ "$all_healthy" = "true" ]; then
+                echo "All platform apps are Healthy."
+                exit 0
+              fi
+              sleep 5
+            done
+          EOT
+          ]
+
+          # Forces a fresh Job (Kubernetes rejects in-place updates to a
+          # Job's pod template — Terraform replaces the whole resource
+          # instead) whenever the platform apps are actually re-applied,
+          # same "re-run the wait on redeploy" behavior the previous
+          # null_resource got from its own `triggers` block.
+          env {
+            name  = "PLATFORM_APPS_REVISION"
+            value = helm_release.argocd_platform_apps.metadata.revision
+          }
+        }
+      }
+    }
   }
+
+  wait_for_completion = true
+
+  timeouts {
+    create = "16m"
+  }
+
+  depends_on = [
+    helm_release.argocd_platform_apps,
+    kubernetes_role_binding.wait_platform_apps,
+  ]
 }

--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -444,6 +444,13 @@ resource "helm_release" "argocd_platform_apps" {
   # forever, since nothing told ArgoCD's own graceful teardown to finish
   # first. monitoring/velero's namespaces never had this problem only by
   # accident, via their own four secrets already being listed here.
+  #
+  # null_resource.velero_namespace_predelete_cleanup (main.tf) is included
+  # here too, for the DESTROY direction specifically: "A depends_on B"
+  # means A destroys before B, so listing that null_resource here makes
+  # THIS release destroy (and therefore Velero's controller die) BEFORE
+  # that cleanup's local-exec runs -- see that resource's own comment in
+  # main.tf for the two earlier, wrong attempts at this ordering.
   depends_on = [
     helm_release.argocd,
     kubernetes_secret.scaleway_s3_credentials,
@@ -452,6 +459,7 @@ resource "helm_release" "argocd_platform_apps" {
     kubernetes_secret.loki_s3_credentials,
     kubernetes_secret.tempo_s3_credentials,
     kubernetes_secret.velero_scaleway_credentials,
+    null_resource.velero_namespace_predelete_cleanup,
   ]
 
   values = [<<EOF

--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -742,3 +742,86 @@ resource "kubernetes_job_v1" "wait_platform_apps_healthy" {
     kubernetes_role_binding.wait_platform_apps,
   ]
 }
+
+# Confirmed live (2026-08-25): without this, `terraform apply` reports
+# success the moment helm_release.argocd_apps creates the bootstrap
+# Application *object* — Helm's own --wait readiness checks understand
+# built-in Kubernetes kinds (Deployment/StatefulSet/PVC/...), not ArgoCD's
+# Application CRD health semantics, so it doesn't actually wait for
+# bootstrap's own sync to finish. That's misleading on its own (an apply
+# reported "done" while the cluster is still converging its entire
+# gitops-repo tree underneath it), and it directly caused real confusion
+# mid-session: a `terraform destroy` issued right after such an apply hit
+# bootstrap still mid-forward-sync (waiting on its own wave 2), and only
+# started actually cascade-deleting once that finished — several extra
+# minutes of "why is this still creating things during a destroy" that a
+# genuine wait here would have avoided by making `apply` block until
+# bootstrap is truly done converging. Reuses the same RBAC as
+# wait_platform_apps_healthy above (same permissions: read Applications
+# in argocd) — no reason for a second ServiceAccount/Role pair.
+resource "kubernetes_job_v1" "wait_bootstrap_healthy" {
+  metadata {
+    name      = "wait-bootstrap-healthy"
+    namespace = "argocd"
+  }
+
+  spec {
+    # bootstrap's own tree is at least as deep as the four platform-apps
+    # domains combined (dex, grafana, wireguard, argo-workflows, demo, every
+    # remaining *-gateway chart) — same budget as
+    # wait_platform_apps_healthy, no evidence yet it needs to differ.
+    active_deadline_seconds = 1800
+    backoff_limit           = 0
+
+    template {
+      metadata {
+        labels = {
+          "app.kubernetes.io/name" = "wait-bootstrap-healthy"
+        }
+      }
+
+      spec {
+        service_account_name = kubernetes_service_account.wait_platform_apps.metadata[0].name
+        restart_policy       = "Never"
+
+        container {
+          name  = "wait"
+          image = "alpine/kubectl:1.35.3"
+
+          command = ["sh", "-c", <<-EOT
+            set -eu
+            while true; do
+              sync=$(kubectl get application bootstrap -n argocd -o jsonpath='{.status.sync.status}' 2>/dev/null || true)
+              health=$(kubectl get application bootstrap -n argocd -o jsonpath='{.status.health.status}' 2>/dev/null || true)
+              if [ "$sync" = "Synced" ] && [ "$health" = "Healthy" ]; then
+                echo "Application/bootstrap is Synced and Healthy."
+                exit 0
+              fi
+              echo "Application/bootstrap: sync=$${sync:-<none yet>} health=$${health:-<none yet>}"
+              sleep 5
+            done
+          EOT
+          ]
+
+          # Same "force a fresh Job on redeploy" trick as
+          # wait_platform_apps_healthy's own env var above.
+          env {
+            name  = "BOOTSTRAP_REVISION"
+            value = helm_release.argocd_apps.metadata.revision
+          }
+        }
+      }
+    }
+  }
+
+  wait_for_completion = true
+
+  timeouts {
+    create = "35m"
+  }
+
+  depends_on = [
+    helm_release.argocd_apps,
+    kubernetes_role_binding.wait_platform_apps,
+  ]
+}

--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -556,7 +556,23 @@ EOF
 # local-exec provisioner: no dependency on a local `kubectl` binary or a
 # self-generated kubeconfig, works identically whether this root is applied
 # from an admin's machine or CI.
+
+# Confirmed live (2026-08-25): without an explicit depends_on, nothing
+# ordered these after anything more than scaleway_k8s_cluster.this itself
+# (the only hard dependency the kubernetes/helm provider configs create) --
+# Terraform fired both RBAC resources ~6s after the cluster control plane
+# finished, in parallel with scaleway_k8s_pool.default (which took several
+# more minutes), and hit DNS resolution failures on the cluster's own API
+# hostname twice in a row at exactly this point. Every kubernetes_namespace
+# resource elsewhere in this file already depends_on the pool for the same
+# reason; these two need it too -- and since they create objects INSIDE the
+# `argocd` namespace, which helm_release.argocd itself creates
+# (create_namespace = true), depending on that release directly covers
+# both "pool is ready" (it has its own depends_on) and "the namespace these
+# actually need exists" in one dependency.
 resource "kubernetes_service_account" "wait_platform_apps" {
+  depends_on = [helm_release.argocd]
+
   metadata {
     name      = "wait-platform-apps-healthy"
     namespace = "argocd"
@@ -564,6 +580,8 @@ resource "kubernetes_service_account" "wait_platform_apps" {
 }
 
 resource "kubernetes_role" "wait_platform_apps" {
+  depends_on = [helm_release.argocd]
+
   metadata {
     name      = "wait-platform-apps-healthy"
     namespace = "argocd"

--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -342,8 +342,8 @@ resource "helm_release" "argocd_apps" {
 
   # wait_platform_apps_healthy (below) is the real Terraform-enforced
   # prerequisite: bootstrap's Application must not even be created until
-  # secrets-apps/monitoring-apps/backups-apps are Healthy — see
-  # platform-apps/README.md.
+  # secrets-apps/monitoring-apps/backups-apps/networking-apps are Healthy —
+  # see platform-apps/README.md.
   depends_on = [helm_release.argocd, null_resource.wait_platform_apps_healthy]
 
   values = [<<EOF
@@ -380,16 +380,17 @@ EOF
   ]
 }
 
-# ── Secrets/monitoring/backups, extracted from gitops repo (infra#84) ───────
+# ── Secrets/monitoring/backups/networking, extracted from gitops repo (infra#84) ───
 #
-# Three parent Applications (secrets-apps/monitoring-apps/backups-apps),
-# each pointing at this repo's own platform-apps/ chart (not gitops) for
-# their OWN list of child Applications — see that chart's README.md for the
-# full "why" (ArgoCD sync-wave only orders resources within one parent
-# Application's own sync, so three separate parents is what actually lets
-# these domains start in parallel with each other while keeping each
-# domain's own real intra-domain ordering, e.g. kube-prometheus-stack-crds
-# before kube-prometheus-stack). The child Applications' own charts
+# Four parent Applications (secrets-apps/monitoring-apps/backups-apps/
+# networking-apps), each pointing at this repo's own platform-apps/ chart
+# (not gitops) for their OWN list of child Applications — see that chart's
+# README.md for the full "why" (ArgoCD sync-wave only orders resources
+# within one parent Application's own sync, so separate parents is what
+# actually lets these domains start in parallel with each other while
+# keeping each domain's own real intra-domain ordering, e.g.
+# kube-prometheus-stack-crds before kube-prometheus-stack, or
+# envoy-gateway/cert-manager before gateway-config). The child Applications' own charts
 # (services/platform/openbao/chart, monitoring/chart, ...) are untouched,
 # still pulled from the gitops repo, same as before this split — only which
 # parent Application claims them as managed resources changed.
@@ -485,6 +486,31 @@ applications:
         selfHeal: true
       syncOptions:
         - CreateNamespace=true
+
+  networking-apps:
+    namespace: argocd
+    project: default
+    source:
+      repoURL: https://github.com/IntegratedDynamic/infrastructure.git
+      targetRevision: ${var.infra_revision}
+      path: 10-cluster/scaleway/platform-apps
+      helm:
+        valueFiles:
+          - values-networking.yaml
+        parameters:
+          - name: revision
+            value: ${var.gitops_revision}
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: argocd
+    syncPolicy:
+      retry:
+        limit: 10
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
 EOF
   ]
 }
@@ -520,8 +546,9 @@ resource "local_sensitive_file" "platform_apps_wait_kubeconfig" {
 }
 
 # The Terraform-enforced prerequisite itself: secrets-apps/monitoring-apps/
-# backups-apps must all reach Healthy before bootstrap's own Application
-# resource is even created (see that resource's depends_on above) — ArgoCD
+# backups-apps/networking-apps must all reach Healthy before bootstrap's own
+# Application resource is even created (see that resource's depends_on
+# above) — ArgoCD
 # has no native way to express "wait for these independent top-level
 # Applications" (sync-wave doesn't cross Application boundaries), so this is
 # enforced as a real Terraform apply-order dependency instead. Polls rather
@@ -540,7 +567,7 @@ resource "null_resource" "wait_platform_apps_healthy" {
     command = <<-EOT
       set -eu
       export KUBECONFIG=${local_sensitive_file.platform_apps_wait_kubeconfig.filename}
-      for app in secrets-apps monitoring-apps backups-apps; do
+      for app in secrets-apps monitoring-apps backups-apps networking-apps; do
         echo "Waiting for Application/$app to become Healthy..."
         deadline=$(($(date +%s) + 600))
         while true; do

--- a/10-cluster/scaleway/main.tf
+++ b/10-cluster/scaleway/main.tf
@@ -289,8 +289,21 @@ resource "kubernetes_namespace" "velero" {
 # can't guarantee those resources' state still exists during a partial
 # destroy. Stashing them here at create time, read back via `self.triggers`
 # at destroy time, is the standard workaround.
+#
+# depends_on BOTH the namespace AND argocd.tf's helm_release.argocd_platform_apps
+# -- confirmed live (2026-08-25) that depending on the namespace alone was
+# not enough: the namespace's OWN destroy is itself gated behind that
+# release finishing its cascade-delete first (same secret-chain ordering
+# fix as kubernetes_namespace.openbao above), which can take many minutes.
+# With only the namespace as a dependency, Terraform was free to run this
+# cleanup as early as possible in the whole destroy -- long before the
+# namespace destroy was actually attempted -- leaving a real window where
+# Velero, still running, recreates the exact Restore objects this had
+# already stripped. Depending on both makes this run immediately adjacent
+# to the namespace destroy it exists to unblock, not whenever Terraform
+# happens to schedule it.
 resource "null_resource" "velero_namespace_predelete_cleanup" {
-  depends_on = [kubernetes_namespace.velero]
+  depends_on = [kubernetes_namespace.velero, helm_release.argocd_platform_apps]
 
   triggers = {
     host      = scaleway_k8s_cluster.this.kubeconfig[0].host

--- a/10-cluster/scaleway/main.tf
+++ b/10-cluster/scaleway/main.tf
@@ -290,20 +290,39 @@ resource "kubernetes_namespace" "velero" {
 # destroy. Stashing them here at create time, read back via `self.triggers`
 # at destroy time, is the standard workaround.
 #
-# depends_on BOTH the namespace AND argocd.tf's helm_release.argocd_platform_apps
-# -- confirmed live (2026-08-25) that depending on the namespace alone was
-# not enough: the namespace's OWN destroy is itself gated behind that
-# release finishing its cascade-delete first (same secret-chain ordering
-# fix as kubernetes_namespace.openbao above), which can take many minutes.
-# With only the namespace as a dependency, Terraform was free to run this
+# Two attempts to get this ordering right, both confirmed live
+# (2026-08-25):
+#
+# 1st attempt: depends_on = [kubernetes_namespace.velero] alone. Wrong --
+# the namespace's OWN destroy is gated behind helm_release.argocd_platform_apps
+# finishing its cascade-delete first (same secret-chain ordering fix as
+# kubernetes_namespace.openbao above), which can take many minutes. With
+# only the namespace as a dependency, Terraform was free to run this
 # cleanup as early as possible in the whole destroy -- long before the
-# namespace destroy was actually attempted -- leaving a real window where
-# Velero, still running, recreates the exact Restore objects this had
-# already stripped. Depending on both makes this run immediately adjacent
-# to the namespace destroy it exists to unblock, not whenever Terraform
-# happens to schedule it.
+# namespace destroy was actually attempted.
+#
+# 2nd attempt: depends_on = [kubernetes_namespace.velero,
+# helm_release.argocd_platform_apps]. ALSO wrong, in the opposite
+# direction -- Terraform's actual rule is "A depends_on B" means A is
+# destroyed BEFORE B, not after. Adding that release here made this
+# cleanup run BEFORE argocd_platform_apps even starts destroying, not
+# after it finishes -- earlier still than the 1st attempt. Confirmed live:
+# the same 2 Restore objects got stuck again, because Velero's controller
+# was still fully alive when the strip ran and simply re-added the
+# finalizer on its own next reconcile (correct, expected behavior for a
+# well-behaved operator watching a resource that isn't actually being
+# deleted yet -- not a bug in Velero).
+#
+# The actual fix: this resource only needs `depends_on` the namespace (so
+# it destroys immediately before it, same as ever). The ordering relative
+# to argocd_platform_apps is enforced from the OTHER side instead --
+# argocd.tf's helm_release.argocd_platform_apps now depends_on THIS
+# resource, which (by the same rule, applied correctly this time) makes
+# that release destroy BEFORE this cleanup, i.e. this cleanup runs AFTER
+# that release's entire cascade-delete has already completed and Velero's
+# pod is confirmed gone -- no controller left alive to re-add anything.
 resource "null_resource" "velero_namespace_predelete_cleanup" {
-  depends_on = [kubernetes_namespace.velero, helm_release.argocd_platform_apps]
+  depends_on = [kubernetes_namespace.velero]
 
   triggers = {
     host      = scaleway_k8s_cluster.this.kubeconfig[0].host

--- a/10-cluster/scaleway/main.tf
+++ b/10-cluster/scaleway/main.tf
@@ -229,3 +229,103 @@ resource "kubernetes_secret" "openbao_unseal_aws" {
     AWS_SECRET_ACCESS_KEY = data.terraform_remote_state.openbao_unseal_aws.outputs.openbao_unseal_secret_access_key
   }
 }
+
+# ── Secrets/monitoring/backups direct provisioning (infra#84) ───────────────
+#
+# monitoring/velero namespaces: Terraform-managed for the same reason
+# kubernetes_namespace.openbao above already was — the Secrets below must
+# exist before ArgoCD's own CreateNamespace=true sync gets a chance to run,
+# not after. external-secrets/secrets-sync namespaces get no such treatment
+# (see argocd-platform-apps/README.md's "Namespace decision") since nothing
+# Terraform-side writes into them.
+resource "kubernetes_namespace" "monitoring" {
+  metadata {
+    name = "monitoring"
+  }
+  depends_on = [scaleway_k8s_pool.default]
+}
+
+resource "kubernetes_namespace" "velero" {
+  metadata {
+    name = "velero"
+  }
+  depends_on = [scaleway_k8s_pool.default]
+}
+
+# thanos-objstore-config / loki-s3-credentials / tempo-s3-credentials /
+# velero-scaleway-credentials: written directly here instead of via
+# OpenBao+ESO's ExternalSecret round-trip (gitops repo's former
+# monitoring/thanos-secret, loki-secret, tempo-secret, velero/secret charts
+# — deleted, see platform-apps/README.md's "The secret-delivery pattern").
+# Terraform already originates all four credentials (03-storage/scaleway's
+# workload identities, read here via the same data.terraform_remote_state.backup_scaleway
+# 11-secrets/openbao/managed also reads) so there's no reason to hand them
+# to ESO just to hand them back — OpenBao stays the audited source of truth
+# via 11-secrets/openbao/managed's own vault_kv_secret_v2 writes (unchanged,
+# dual-written independently of this Secret).
+resource "kubernetes_secret" "thanos_objstore_config" {
+  metadata {
+    name      = "thanos-objstore-config"
+    namespace = kubernetes_namespace.monitoring.metadata[0].name
+  }
+
+  data = {
+    # Matches gitops repo's former monitoring/thanos-secret ExternalSecret
+    # template exactly (single objstore.yaml key, Thanos's own format:
+    # https://thanos.io/tip/thanos/storage.md/#s3) — bucket/endpoint/region
+    # kept in sync by hand with 03-storage/scaleway/env/*.tfvars' thanos
+    # entry, same convention that chart's values.yaml already documented.
+    "objstore.yaml" = yamlencode({
+      type = "S3"
+      config = {
+        bucket     = data.terraform_remote_state.backup_scaleway.outputs.thanos_bucket_name
+        endpoint   = "s3.fr-par.scw.cloud"
+        region     = "fr-par"
+        access_key = data.terraform_remote_state.backup_scaleway.outputs.thanos_workload_access_key
+        secret_key = data.terraform_remote_state.backup_scaleway.outputs.thanos_workload_secret_key
+      }
+    })
+  }
+}
+
+resource "kubernetes_secret" "loki_s3_credentials" {
+  metadata {
+    name      = "loki-s3-credentials"
+    namespace = kubernetes_namespace.monitoring.metadata[0].name
+  }
+
+  data = {
+    AWS_ACCESS_KEY_ID     = data.terraform_remote_state.backup_scaleway.outputs.loki_workload_access_key
+    AWS_SECRET_ACCESS_KEY = data.terraform_remote_state.backup_scaleway.outputs.loki_workload_secret_key
+  }
+}
+
+resource "kubernetes_secret" "tempo_s3_credentials" {
+  metadata {
+    name      = "tempo-s3-credentials"
+    namespace = kubernetes_namespace.monitoring.metadata[0].name
+  }
+
+  data = {
+    AWS_ACCESS_KEY_ID     = data.terraform_remote_state.backup_scaleway.outputs.tempo_workload_access_key
+    AWS_SECRET_ACCESS_KEY = data.terraform_remote_state.backup_scaleway.outputs.tempo_workload_secret_key
+  }
+}
+
+resource "kubernetes_secret" "velero_scaleway_credentials" {
+  metadata {
+    name      = "velero-scaleway-credentials"
+    namespace = kubernetes_namespace.velero.metadata[0].name
+  }
+
+  data = {
+    # Matches gitops repo's former velero/secret ExternalSecret template
+    # exactly (single "cloud" key, AWS shared-config/INI format
+    # velero-plugin-for-aws reads via credentials.existingSecret).
+    cloud = <<-EOT
+      [default]
+      aws_access_key_id=${data.terraform_remote_state.backup_scaleway.outputs.velero_workload_access_key}
+      aws_secret_access_key=${data.terraform_remote_state.backup_scaleway.outputs.velero_workload_secret_key}
+    EOT
+  }
+}

--- a/10-cluster/scaleway/main.tf
+++ b/10-cluster/scaleway/main.tf
@@ -265,9 +265,23 @@ resource "kubernetes_namespace" "velero" {
 # reliably fix it, since the controller can lose the race regardless of
 # how long we wait). Since a `terraform destroy` tears down the whole
 # cluster anyway, there's no external state left to protect by waiting for
-# Velero's own cleanup -- this proactively strips finalizers from every
-# velero.io-group object in the namespace right before the namespace
-# itself is destroyed, instead of hoping the race goes the other way.
+# Velero's own cleanup -- this proactively strips finalizers from the
+# known Restore objects right before the namespace itself is destroyed,
+# instead of hoping the race goes the other way.
+#
+# Deliberately curl-based, not kubectl-based: this root's execution
+# environment (an admin's machine, or CI, per this repo's own convention)
+# is not guaranteed to have kubectl installed, only whatever the
+# provisioner itself can assume -- curl ships on essentially every base
+# OS/CI image already, kubectl does not. Named restore objects, not a
+# discovery loop (`kubectl api-resources`/`get` equivalent), for the same
+# reason -- there is no portable curl-only way to enumerate a CRD's
+# instances without a JSON-parsing tool (jq etc.) that's just as
+# unguaranteed as kubectl itself. Add to this list if a future gitops-repo
+# PreSync restore hook creates another named Restore
+# (services/platform/gateway/config's cert-restore and
+# services/platform/monitoring/grafana-chart's grafana-restore are the
+# only two today).
 #
 # Connection details are captured in `triggers` (not referenced directly
 # in the provisioner) because a destroy-time provisioner may only
@@ -288,22 +302,23 @@ resource "null_resource" "velero_namespace_predelete_cleanup" {
     when       = destroy
     on_failure = continue
 
-    # No kubeconfig file: plain --server/--token flags avoid nesting a
-    # bash heredoc inside this HCL heredoc (indentation-stripping rules
-    # differ between the two -- Terraform's `<<-` strips based on the
-    # closing marker's own column, bash's `<<-` only strips literal tabs
-    # -- fragile to get both right at once). --insecure-skip-tls-verify is
-    # an acceptable tradeoff here: this cluster is mid-destroy, and the
-    # token already came straight out of Terraform state on the same
-    # machine, so skipping CA validation adds no meaningful exposure.
+    # curl -k (skip TLS verify): acceptable here -- this cluster is
+    # mid-destroy, and the token already came straight out of Terraform
+    # state on the same machine, so skipping CA validation adds no
+    # meaningful exposure. `|| true` per call: a 404 (object never
+    # existed, e.g. a fresh cluster with no restore history yet) is a
+    # normal outcome, not a failure.
     command = <<-EOT
       set -eu
-      kc="kubectl --server=${self.triggers.host} --token=${self.triggers.token} --insecure-skip-tls-verify=true"
-      for kind in $($kc api-resources --api-group=velero.io --namespaced -o name 2>/dev/null); do
-        for obj in $($kc get "$kind" -n "${self.triggers.namespace}" -o name 2>/dev/null); do
-          echo "Stripping finalizers from $obj before namespace delete..."
-          $kc patch "$obj" -n "${self.triggers.namespace}" --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
-        done
+      for name in cert-secrets-restore grafana-pvc-restore; do
+        echo "Stripping finalizers from restores.velero.io/$name (if present) before namespace delete..."
+        curl -sS -k -o /dev/null \
+          -X PATCH \
+          -H "Authorization: Bearer ${self.triggers.token}" \
+          -H "Content-Type: application/merge-patch+json" \
+          -d '{"metadata":{"finalizers":[]}}' \
+          "${self.triggers.host}/apis/velero.io/v1/namespaces/${self.triggers.namespace}/restores/$name" \
+          || true
       done
     EOT
   }

--- a/10-cluster/scaleway/main.tf
+++ b/10-cluster/scaleway/main.tf
@@ -252,6 +252,63 @@ resource "kubernetes_namespace" "velero" {
   depends_on = [scaleway_k8s_pool.default]
 }
 
+# Confirmed live (2026-08-25, reproduced twice): destroying this namespace
+# hangs indefinitely (~5min, then `terraform destroy` errors "context
+# deadline exceeded") on Velero's own Restore custom resources (created by
+# gitops repo's cert-restore/grafana-restore PreSync hooks), which carry
+# `restores.velero.io/external-resources-finalizer` -- a finalizer only
+# Velero's own controller ever removes, by reconciling it. Kubernetes gives
+# no ordering guarantee that a namespace's contained custom resources get
+# their finalizers processed before the controller that owns those
+# finalizers is itself torn down as part of the SAME cascading namespace
+# delete -- a genuine race, not just slowness (a longer timeout doesn't
+# reliably fix it, since the controller can lose the race regardless of
+# how long we wait). Since a `terraform destroy` tears down the whole
+# cluster anyway, there's no external state left to protect by waiting for
+# Velero's own cleanup -- this proactively strips finalizers from every
+# velero.io-group object in the namespace right before the namespace
+# itself is destroyed, instead of hoping the race goes the other way.
+#
+# Connection details are captured in `triggers` (not referenced directly
+# in the provisioner) because a destroy-time provisioner may only
+# reference `self` or input variables, never other resources -- Terraform
+# can't guarantee those resources' state still exists during a partial
+# destroy. Stashing them here at create time, read back via `self.triggers`
+# at destroy time, is the standard workaround.
+resource "null_resource" "velero_namespace_predelete_cleanup" {
+  depends_on = [kubernetes_namespace.velero]
+
+  triggers = {
+    host      = scaleway_k8s_cluster.this.kubeconfig[0].host
+    token     = scaleway_k8s_cluster.this.kubeconfig[0].token
+    namespace = kubernetes_namespace.velero.metadata[0].name
+  }
+
+  provisioner "local-exec" {
+    when       = destroy
+    on_failure = continue
+
+    # No kubeconfig file: plain --server/--token flags avoid nesting a
+    # bash heredoc inside this HCL heredoc (indentation-stripping rules
+    # differ between the two -- Terraform's `<<-` strips based on the
+    # closing marker's own column, bash's `<<-` only strips literal tabs
+    # -- fragile to get both right at once). --insecure-skip-tls-verify is
+    # an acceptable tradeoff here: this cluster is mid-destroy, and the
+    # token already came straight out of Terraform state on the same
+    # machine, so skipping CA validation adds no meaningful exposure.
+    command = <<-EOT
+      set -eu
+      kc="kubectl --server=${self.triggers.host} --token=${self.triggers.token} --insecure-skip-tls-verify=true"
+      for kind in $($kc api-resources --api-group=velero.io --namespaced -o name 2>/dev/null); do
+        for obj in $($kc get "$kind" -n "${self.triggers.namespace}" -o name 2>/dev/null); do
+          echo "Stripping finalizers from $obj before namespace delete..."
+          $kc patch "$obj" -n "${self.triggers.namespace}" --type=merge -p '{"metadata":{"finalizers":[]}}' 2>/dev/null || true
+        done
+      done
+    EOT
+  }
+}
+
 # thanos-objstore-config / loki-s3-credentials / tempo-s3-credentials /
 # velero-scaleway-credentials: written directly here instead of via
 # OpenBao+ESO's ExternalSecret round-trip (gitops repo's former

--- a/10-cluster/scaleway/platform-apps/Chart.yaml
+++ b/10-cluster/scaleway/platform-apps/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: platform-apps
+description: >-
+  Renders one domain's ArgoCD child Applications (secrets, monitoring, or
+  backups — see values-*.yaml) as this chart's own managed resources, so
+  ArgoCD's sync-wave ordering applies within the domain. Pulled directly by
+  ArgoCD (source.path in argocd.tf's argocd_platform_apps helm_release) — see
+  README.md for why this lives here instead of the gitops repo.
+type: application
+version: 0.1.0

--- a/10-cluster/scaleway/platform-apps/README.md
+++ b/10-cluster/scaleway/platform-apps/README.md
@@ -1,22 +1,33 @@
-# `platform-apps` — secrets/monitoring/backups, extracted from gitops (infra#84)
+# `platform-apps` — secrets/monitoring/backups/networking, extracted from gitops (infra#84)
 
 ## Why this exists
 
 Before this split, `gitops` repo's `bootstrap` app-of-apps managed OpenBao,
-ESO, monitoring (kube-prometheus-stack/loki/tempo/alloy/otel-collector), and
-Velero as its own sync-waves 0-4, sequentially — even though none of these
-three domains actually depend on each other, or on anything else in
-`bootstrap`'s later waves (gateway/dex/product apps). Investigation
-(2026-08-24) found these waves among the slowest in a full bootstrap
+ESO, monitoring (kube-prometheus-stack/loki/tempo/alloy/otel-collector),
+Velero, and cluster networking (envoy-gateway/cert-manager/external-dns/
+gateway-config) as its own sequential sync-waves — even though none of
+these four domains actually depend on each other, or on anything else in
+`bootstrap`'s later waves (dex/product apps). Investigation (2026-08-24)
+found these waves among the slowest in a full bootstrap
 (`kube-prometheus-stack` ~2m14s to Healthy), each wave paying a further
 1-2min gap on top even when the healthcheck poll itself was fast.
+Networking was added to the scope a day later (same issue, see infra#84's
+comment thread) for the same reason: it's platform-level infra, same as
+the first three, and overlaps this repo's own `04-vpn` domain already.
 
 This chart, plus `argocd.tf`'s `argocd_platform_apps` helm_release and
-`wait_platform_apps_healthy` null_resource, extracts those three domains
+`wait_platform_apps_healthy` null_resource, extracts those four domains
 into their own parallel-starting parent Applications, gated as a real
 Terraform-enforced prerequisite of `bootstrap` (not a consequence of it).
 
-## Why three separate value files, not one list
+Every product-specific `*-gateway` HTTPRoute chart (`dex-gateway`,
+`grafana-gateway`, `argocd-config-gateway`, `openbao-gateway`,
+`argo-workflows-gateway`) stays in `gitops` repo's `bootstrap` — those are
+per-product exposure, not shared routing infrastructure, and their own
+prerequisite (`networking-apps`' Gateway object) is now ready even earlier
+than before.
+
+## Why four separate value files, not one list
 
 ArgoCD's sync-wave annotation only orders resources **within one parent
 Application's own sync** — confirmed live in gitops repo's
@@ -24,23 +35,43 @@ Application's own sync** — confirmed live in gitops repo's
 not an ApplicationSet"). Two independent top-level Applications get zero
 ordering between them, automated sync policy or not.
 
-Secrets and monitoring both still have a real *intra-domain* ordering
-requirement inherited from the original bootstrap waves (openbao before
-openbao-init sharing a wave is fine — self-heals; kube-prometheus-stack-crds
-finishing **before** kube-prometheus-stack starts is a hard, non-self-healing
-requirement — see gitops repo's `bootstrap/README.md` wave 2 for the
-confirmed-live incident). Splitting into three separate parent Applications
-(`secrets-apps`, `monitoring-apps`, `backups-apps` — see `argocd.tf`) keeps
-each domain's own proven sync-wave ordering intact while giving up nothing:
-the three parents themselves have no ordering *between* them, which is
-exactly the "start in parallel" requirement.
+Secrets, monitoring, and networking all still have a real *intra-domain*
+ordering requirement inherited from the original bootstrap waves (openbao
+before openbao-init sharing a wave is fine — self-heals;
+kube-prometheus-stack-crds finishing **before** kube-prometheus-stack starts
+is a hard, non-self-healing requirement — see gitops repo's
+`bootstrap/README.md` wave 2 for the confirmed-live incident; gateway-config
+needing envoy-gateway's AND cert-manager's CRDs to have actually landed
+before it can create its `ClusterIssuer`s is the same class of hard
+dependency, wave 5 in that same file). Splitting into four separate parent
+Applications (`secrets-apps`, `monitoring-apps`, `backups-apps`,
+`networking-apps` — see `argocd.tf`) keeps each domain's own proven
+sync-wave ordering intact while giving up nothing: the four parents
+themselves have no ordering *between* them, which is exactly the "start in
+parallel" requirement.
+
+`networking-apps` additionally has a *soft* cross-domain dependency on
+`secrets-apps`: `cert-manager-webhook-secret`/`external-dns-secret` are
+still ESO `ExternalSecret`s (see "The secret-delivery pattern" below), so
+they need OpenBao+ESO reachable to resolve. This is deliberately left
+ungated — same "brief race, self-heals via ESO's own refreshInterval"
+tolerance every other `*-secret` chart in `gitops` repo's `bootstrap`
+already accepts, not a new risk this split introduces. `gateway-config`'s
+dependency on Velero (its cert-restore PreSync hook) is similarly left
+ungated on purpose — that hook already queries the `velero` namespace's
+`Backup`/`Restore` objects directly via the Kubernetes API and fails open
+if none shows up within its own budget, independent of which anything
+ArgoCD-side is Healthy (see `gitops` repo's
+`services/platform/gateway/config/README.md`, and infra#84's issue
+comments for why an ArgoCD-sync-wave-based attempt at this exact
+dependency was tried and abandoned before this split even existed).
 
 ## Why the cross-domain "finish before bootstrap" gate is Terraform, not ArgoCD
 
 Same reasoning as above, the other direction: there is no ArgoCD-native way
 to say "don't even start syncing Application X until Applications A/B/C are
 Healthy" when A/B/C/X are independent top-level Applications. `argocd.tf`'s
-`null_resource.wait_platform_apps_healthy` polls the three parent
+`null_resource.wait_platform_apps_healthy` polls the four parent
 Applications' `.status.health.status` via `kubectl` (using a
 Terraform-generated kubeconfig, not `~/.kube/config` — self-contained,
 works whether or not `var.update_kubeconfig` ran) before the `bootstrap`
@@ -64,6 +95,12 @@ The issue's original hypothesis (Velero might be slow because Argo creates
 its backup-target namespaces one at a time across waves) was never verified
 either way — moot here, since `velero`'s namespace ends up Terraform-managed
 regardless, for the secret-ordering reason above, not a startup-speed one.
+
+`networking-apps`' namespaces (`cert-manager`, `envoy-gateway-system`,
+`gateway`, `external-dns`) get no such treatment either — same as
+`external-secrets`/`secrets-sync` above, nothing Terraform-side writes into
+them (this domain keeps using ESO, see below), so they stay
+`CreateNamespace=true`-created by their own Application.
 
 ## The secret-delivery pattern (infra#84's other open question)
 
@@ -92,4 +129,13 @@ This is deliberately narrower than the issue's original "pre-populate +
 touches them), there's no OpenBao/ESO reconciler to race or ignore —
 `ignore_changes` would have nothing to protect against here. Every other
 product's own secret (dex-secret, external-dns-secret, grafana-secret, ...)
-is untouched and stays exactly on the OpenBao+ESO path it was on before.
+is untouched and stays exactly on the OpenBao+ESO path it was on before —
+**including `networking-apps`' own `cert-manager-webhook-secret` and
+`external-dns-secret`**, added to this chart later (infra#84's comment
+thread). Terraform doesn't originate the Scaleway Domains/DNS API
+credential either of those materialize (unlike thanos/loki/tempo/velero's
+Object Storage keys, which come straight from this same repo's
+`03-storage/scaleway`) — there's nothing to gain by bypassing ESO for a
+credential Terraform has no more direct a line to than ESO already does, so
+this domain deliberately keeps the existing mechanism rather than applying
+the direct-`kubernetes_secret` pattern uniformly.

--- a/10-cluster/scaleway/platform-apps/README.md
+++ b/10-cluster/scaleway/platform-apps/README.md
@@ -1,0 +1,95 @@
+# `platform-apps` — secrets/monitoring/backups, extracted from gitops (infra#84)
+
+## Why this exists
+
+Before this split, `gitops` repo's `bootstrap` app-of-apps managed OpenBao,
+ESO, monitoring (kube-prometheus-stack/loki/tempo/alloy/otel-collector), and
+Velero as its own sync-waves 0-4, sequentially — even though none of these
+three domains actually depend on each other, or on anything else in
+`bootstrap`'s later waves (gateway/dex/product apps). Investigation
+(2026-08-24) found these waves among the slowest in a full bootstrap
+(`kube-prometheus-stack` ~2m14s to Healthy), each wave paying a further
+1-2min gap on top even when the healthcheck poll itself was fast.
+
+This chart, plus `argocd.tf`'s `argocd_platform_apps` helm_release and
+`wait_platform_apps_healthy` null_resource, extracts those three domains
+into their own parallel-starting parent Applications, gated as a real
+Terraform-enforced prerequisite of `bootstrap` (not a consequence of it).
+
+## Why three separate value files, not one list
+
+ArgoCD's sync-wave annotation only orders resources **within one parent
+Application's own sync** — confirmed live in gitops repo's
+`bootstrap/README.md` ("Why sync-wave on one Application's own resources,
+not an ApplicationSet"). Two independent top-level Applications get zero
+ordering between them, automated sync policy or not.
+
+Secrets and monitoring both still have a real *intra-domain* ordering
+requirement inherited from the original bootstrap waves (openbao before
+openbao-init sharing a wave is fine — self-heals; kube-prometheus-stack-crds
+finishing **before** kube-prometheus-stack starts is a hard, non-self-healing
+requirement — see gitops repo's `bootstrap/README.md` wave 2 for the
+confirmed-live incident). Splitting into three separate parent Applications
+(`secrets-apps`, `monitoring-apps`, `backups-apps` — see `argocd.tf`) keeps
+each domain's own proven sync-wave ordering intact while giving up nothing:
+the three parents themselves have no ordering *between* them, which is
+exactly the "start in parallel" requirement.
+
+## Why the cross-domain "finish before bootstrap" gate is Terraform, not ArgoCD
+
+Same reasoning as above, the other direction: there is no ArgoCD-native way
+to say "don't even start syncing Application X until Applications A/B/C are
+Healthy" when A/B/C/X are independent top-level Applications. `argocd.tf`'s
+`null_resource.wait_platform_apps_healthy` polls the three parent
+Applications' `.status.health.status` via `kubectl` (using a
+Terraform-generated kubeconfig, not `~/.kube/config` — self-contained,
+works whether or not `var.update_kubeconfig` ran) before the `bootstrap`
+Application resource is created at all. This is a real `depends_on`
+enforced by Terraform's own apply order, not a sync-wave — the only
+mechanism that can span independent top-level Applications.
+
+## Namespace decision (infra#84's open question)
+
+Namespaces are **not** wholesale extracted to Terraform. `monitoring` and
+`velero` get Terraform-managed `kubernetes_namespace` resources in this
+root's `main.tf`, same pattern `openbao` already used before this split —
+but *only* because Terraform now writes Kubernetes Secrets into them ahead
+of ArgoCD's own sync (see below), and a Secret can't be created before its
+namespace exists. `external-secrets` and `secrets-sync` get no such
+treatment — nothing Terraform-side writes into those namespaces, so they
+stay `CreateNamespace=true`-created by their own Application, same as every
+other app in this repo.
+
+The issue's original hypothesis (Velero might be slow because Argo creates
+its backup-target namespaces one at a time across waves) was never verified
+either way — moot here, since `velero`'s namespace ends up Terraform-managed
+regardless, for the secret-ordering reason above, not a startup-speed one.
+
+## The secret-delivery pattern (infra#84's other open question)
+
+For the four credentials Terraform already originates (thanos/loki/tempo/
+velero Object Storage access keys — see `03-storage/scaleway`), the old
+path was Terraform → OpenBao KV (`11-secrets/openbao/managed`) → ESO
+`ExternalSecret` → Kubernetes Secret. That's unchanged in its first half:
+`11-secrets/openbao/managed`'s `vault_kv_secret_v2` resources still write
+these into OpenBao, which stays the audited single source of truth for the
+credential values (per the issue's own comment thread). What's gone is the
+second half — ESO is no longer in the loop for these four. This root's
+`main.tf` now writes the Kubernetes Secret directly
+(`thanos-objstore-config`, `loki-s3-credentials`, `tempo-s3-credentials`,
+`velero-scaleway-credentials`), reading the same
+`data.terraform_remote_state.backup_scaleway` outputs
+`11-secrets/openbao/managed` already reads — no new cross-root wiring, and
+one fewer async hop between "Terraform knows the credential" and "the pod
+that needs it can read it". The four gitops-repo charts that used to do
+this via `ExternalSecret` (`services/platform/velero/secret`,
+`monitoring/thanos-secret`, `monitoring/loki-secret`,
+`monitoring/tempo-secret`) were deleted — see gitops repo PR for infra#84.
+
+This is deliberately narrower than the issue's original "pre-populate +
+`lifecycle { ignore_changes }`" proposal: since these four secrets are
+*entirely* Terraform-owned now (Terraform is the only writer, ESO never
+touches them), there's no OpenBao/ESO reconciler to race or ignore —
+`ignore_changes` would have nothing to protect against here. Every other
+product's own secret (dex-secret, external-dns-secret, grafana-secret, ...)
+is untouched and stays exactly on the OpenBao+ESO path it was on before.

--- a/10-cluster/scaleway/platform-apps/templates/apps.yaml
+++ b/10-cluster/scaleway/platform-apps/templates/apps.yaml
@@ -19,6 +19,19 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: {{ .wave | quote }}
+  # Cascade-deletes this app's own managed resources (its actual Deployment/
+  # Service/etc.) before removing the Application object itself, instead of
+  # the default "just forget about it, leave whatever it deployed running"
+  # behavior. Unconditional, not opt-in per app, same reasoning as
+  # ignoreDifferences below — confirmed live (2026-08-25): without this, a
+  # `terraform destroy` tears down every parent Application in this chart's
+  # tree within seconds, nowhere near enough for anything to gracefully shut
+  # down, e.g. leaving Velero's own pod orphaned right before
+  # kubernetes_namespace.velero's cascade delete races its controller's own
+  # teardown for the Restore CRs' external-resources-finalizer (see that
+  # resource's own comment in 10-cluster/scaleway/main.tf).
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
 spec:
   project: default
 

--- a/10-cluster/scaleway/platform-apps/templates/apps.yaml
+++ b/10-cluster/scaleway/platform-apps/templates/apps.yaml
@@ -1,0 +1,70 @@
+# Same rendering trick gitops repo's bootstrap/templates/scaleway.yaml uses
+# for the exact same reason (see that file's own header comment and
+# bootstrap/README.md's "Why sync-wave on one Application's own resources,
+# not an ApplicationSet"): every Application in .Values.apps is rendered
+# directly as a managed resource of THIS chart's own Application sync (one
+# of secrets-apps/monitoring-apps/backups-apps, see argocd.tf's
+# argocd_platform_apps helm_release) — never an ApplicationSet, since
+# ArgoCD's Progressive Syncs (RollingSync) doesn't gate first-ever creation,
+# only staged updates to an already-existing fleet (confirmed live
+# 2026-08-11 on the gitops repo's own bootstrap chart before it dropped
+# ApplicationSet). Plain sync-wave on one parent's own resources is the
+# mechanism that's actually proven to work for bootstrap ordering.
+{{- range $app := .Values.apps }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .name }}
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ .wave | quote }}
+spec:
+  project: default
+
+  source:
+    repoURL: {{ $.Values.repoURL }}
+    targetRevision: {{ $.Values.revision }}
+    path: {{ .chartPath }}
+    helm:
+      valueFiles:
+        - {{ .valueFile }}
+      {{- if .skipCrds }}
+      # See gitops repo's bootstrap/templates/scaleway.yaml — same
+      # skipCrds/dedicated-CRDs-Application split for kube-prometheus-stack.
+      skipCrds: true
+      {{- end }}
+      {{- if .syncWaveLabelPaths }}
+      # Same anti-affinity wave-label injection as
+      # gitops repo's bootstrap/templates/scaleway.yaml — see that file's
+      # comment for the full "why" (forceString avoids a bare digit
+      # rendering as an unquoted YAML integer label value).
+      parameters:
+        {{- range .syncWaveLabelPaths }}
+        - name: {{ . }}
+          value: {{ $app.wave | quote }}
+          forceString: true
+        {{- end }}
+      {{- end }}
+
+  # Same webhook caBundle exception as gitops repo's
+  # bootstrap/templates/scaleway.yaml — see that file's comment for why this
+  # is unconditional rather than opt-in per app.
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
+      kind: MutatingWebhookConfiguration
+      jqPathExpressions:
+        - '.webhooks[]?.clientConfig.caBundle'
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ .namespace }}
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+{{- end }}

--- a/10-cluster/scaleway/platform-apps/values-backups.yaml
+++ b/10-cluster/scaleway/platform-apps/values-backups.yaml
@@ -1,0 +1,15 @@
+# Velero — extracted from gitops repo's bootstrap/values.yaml wave 4
+# (infra#84). velero-scaleway-credentials is no longer an
+# ExternalSecret-materialized chart (gitops repo's former
+# velero/secret — deleted) — this repo's main.tf now writes that
+# Kubernetes Secret directly (still also written to OpenBao KV by
+# 11-secrets/openbao/managed, which stays the audited source of truth for
+# the credential value itself), since Terraform already owns the bucket +
+# IAM identity it comes from (03-storage/scaleway).
+#
+# Single-app domain, no intra-domain ordering needed — kept as a wave-0
+# list (rather than a bare Application) for the same reason gitops repo's
+# bootstrap chart never special-cases single-wave domains: consistent shape
+# across secrets-apps/monitoring-apps/backups-apps, cheap to extend later.
+apps:
+  - {name: velero, namespace: velero, chartPath: services/platform/velero/chart, valueFile: values-scaleway.yaml, wave: "0", syncWaveLabelPaths: ['velero.podLabels.scalepack\.fr/sync-wave']}

--- a/10-cluster/scaleway/platform-apps/values-monitoring.yaml
+++ b/10-cluster/scaleway/platform-apps/values-monitoring.yaml
@@ -1,0 +1,40 @@
+# Everything that captures/stores cluster data — extracted from gitops
+# repo's bootstrap/values.yaml waves 2-4 (infra#84). Grafana itself (pure
+# consumption/UI, not capture) stays in gitops repo's bootstrap, unaffected
+# — it only needs this domain's `velero` sibling (backups domain, for its
+# grafana-restore-* PreSync hook) to exist, which is now guaranteed true
+# well before bootstrap even starts syncing.
+#
+# thanos-objstore-config / loki-s3-credentials / tempo-s3-credentials: no
+# longer ExternalSecret-materialized charts here (gitops repo's former
+# monitoring/thanos-secret, loki-secret, tempo-secret — deleted) — this
+# repo's main.tf now writes those Kubernetes Secrets directly (still also
+# written to OpenBao KV by 11-secrets/openbao/managed, which stays the
+# audited source of truth for the credential values themselves; see that
+# root's vault_kv_secret_v2 resources), since Terraform already owns the
+# bucket + IAM identity these credentials come from (03-storage/scaleway) —
+# no ESO round-trip needed for a credential Terraform originates itself.
+apps:
+  # ── wave 0 ──────────────────────────────────────────────────────────────
+  # kube-prometheus-stack-crds: a separate, earlier-wave Application purely
+  # so ArgoCD's CRD-Established health check gates kube-prometheus-stack
+  # (wave 1, skipCrds: true) from starting before these are truly ready —
+  # see gitops repo's bootstrap/README.md wave 2 for the confirmed-live
+  # incident (prometheus-operator checks CRD availability once at pod
+  # startup, no retry) this specifically guards against.
+  - {name: kube-prometheus-stack-crds, namespace: monitoring, chartPath: services/platform/monitoring/crds, valueFile: values-scaleway.yaml, wave: "0"}
+
+  # ── wave 1 ──────────────────────────────────────────────────────────────
+  # kube-prometheus-stack + loki + tempo: real prerequisites are wave 0's
+  # CRDs and this repo's directly-provisioned Secrets above — nothing
+  # cert-manager/gateway/dex-related (those stay in gitops repo's
+  # bootstrap, unaffected).
+  - {name: kube-prometheus-stack, namespace: monitoring, chartPath: services/platform/monitoring/chart, valueFile: values-scaleway.yaml, wave: "1", skipCrds: true, syncWaveLabelPaths: ['kube-prometheus-stack.prometheus.prometheusSpec.podMetadata.labels.scalepack\.fr/sync-wave', 'kube-prometheus-stack.prometheusOperator.podLabels.scalepack\.fr/sync-wave']}
+  - {name: loki, namespace: monitoring, chartPath: services/platform/monitoring/loki-chart, valueFile: values-scaleway.yaml, wave: "1"}
+  - {name: tempo, namespace: monitoring, chartPath: services/platform/monitoring/tempo-chart, valueFile: values-scaleway.yaml, wave: "1"}
+
+  # ── wave 2 ──────────────────────────────────────────────────────────────
+  # alloy / otel-collector: one wave after loki/tempo — both need the
+  # loki/tempo Services resolvable, not just created.
+  - {name: alloy, namespace: monitoring, chartPath: services/platform/monitoring/alloy-chart, valueFile: values-scaleway.yaml, wave: "2"}
+  - {name: otel-collector, namespace: monitoring, chartPath: services/platform/otel-collector/chart, valueFile: values-scaleway.yaml, wave: "2"}

--- a/10-cluster/scaleway/platform-apps/values-networking.yaml
+++ b/10-cluster/scaleway/platform-apps/values-networking.yaml
@@ -1,0 +1,65 @@
+# Cluster networking/routing — extracted from gitops repo's bootstrap/values.yaml
+# (infra#84, scope added 2026-08-24: cluster networking is platform-level
+# infra, same as secrets/monitoring/backups, and overlaps this repo's own
+# 04-vpn domain — no reason to leave it in gitops by default rather than by
+# explicit choice). envoy-gateway, cert-manager (+ its Scaleway DNS01
+# webhook), external-dns, and gateway-config (the shared
+# GatewayClass/Gateway/ClusterIssuers every product's own *-gateway
+# HTTPRoute chart attaches to). Every product-specific *-gateway chart
+# (dex-gateway, grafana-gateway, argocd-config-gateway, openbao-gateway,
+# argo-workflows-gateway) stays in gitops repo's bootstrap — those are
+# per-product exposure, not shared routing infrastructure, and their own
+# prerequisite (this domain's Gateway) is now ready even earlier than
+# before.
+#
+# Unlike secrets-apps/monitoring-apps/backups-apps, this domain keeps using
+# OpenBao+ESO for its own secrets (cert-manager-webhook-secret,
+# external-dns-secret) rather than direct Terraform provisioning — these
+# aren't credentials Terraform itself originates (unlike thanos/loki/tempo/
+# velero's Object Storage keys), so there's nothing to gain by bypassing
+# ESO here. Moved together with their consumers (same reasoning as
+# secrets-apps' openbao+openbao-init) since bootstrap no longer runs after
+# this domain — a secret left behind in bootstrap's own wave 1 would apply
+# AFTER its consumer here already tried to start, inverting the ordering
+# these charts depend on.
+#
+# gateway-config's PreSync hook restores its TLS Secret from a Velero
+# backup (services/platform/gateway/config/README.md) — deliberately NOT
+# gated against backups-apps here: that hook already queries the `velero`
+# namespace's Backup/Restore objects directly via the Kubernetes API and
+# fails open (proceeds with a fresh ACME cert) if none shows up within its
+# own budget, the same self-contained mechanism that replaced an earlier,
+# unreliable sync-wave-based attempt (services/platform/velero/init, since
+# removed) — see infra#84's issue comments for the full reasoning. No
+# Terraform-level wait needed between this domain and backups-apps.
+apps:
+  # ── wave 0 ──────────────────────────────────────────────────────────────
+  # cert-manager-webhook-secret / external-dns-secret: still ESO
+  # ExternalSecrets (see header comment above) — self-heal if OpenBao/ESO
+  # (secrets-apps domain) isn't quite ready yet at this domain's own start,
+  # same "brief race, self-heals" tolerance every other *-secret chart in
+  # gitops repo's bootstrap already accepts.
+  - {name: cert-manager-webhook-secret, namespace: cert-manager, chartPath: services/platform/cert-manager/webhook-secret, valueFile: values.yaml, wave: "0"}
+  - {name: external-dns-secret, namespace: external-dns, chartPath: services/platform/external-dns/secret, valueFile: values.yaml, wave: "0"}
+
+  # ── wave 1 ──────────────────────────────────────────────────────────────
+  # envoy-gateway + cert-manager (+ its Scaleway DNS01 ACME webhook): don't
+  # depend on each other — what actually needs both is gateway-config
+  # (wave 2): envoy-gateway for the Gateway API CRDs, cert-manager for the
+  # cert-manager.io CRDs its ClusterIssuers need.
+  - {name: envoy-gateway, namespace: envoy-gateway-system, chartPath: services/platform/gateway/chart, valueFile: values-scaleway.yaml, wave: "1", syncWaveLabelPaths: ['gateway-helm.deployment.pod.labels.scalepack\.fr/sync-wave']}
+  - {name: cert-manager, namespace: cert-manager, chartPath: services/platform/cert-manager/chart, valueFile: values-scaleway.yaml, wave: "1", syncWaveLabelPaths: ['cert-manager.podLabels.scalepack\.fr/sync-wave', 'cert-manager.webhook.podLabels.scalepack\.fr/sync-wave', 'cert-manager.cainjector.podLabels.scalepack\.fr/sync-wave']}
+  - {name: cert-manager-webhook-scaleway, namespace: cert-manager, chartPath: services/platform/cert-manager/webhook-chart, valueFile: values-scaleway.yaml, wave: "1", syncWaveLabelPaths: ['scaleway-certmanager-webhook.podLabels.scalepack\.fr/sync-wave']}
+
+  # ── wave 2 ──────────────────────────────────────────────────────────────
+  # gateway-config needs BOTH wave 1's envoy-gateway (Gateway API CRDs) AND
+  # cert-manager (cert-manager.io CRDs) to have actually finished
+  # installing, not just exist — a genuinely hard dependency (its
+  # ClusterIssuer objects are cert-manager.io-typed; ArgoCD's sync fails
+  # outright at the API level, no self-heal, if that CRD isn't registered
+  # yet). external-dns doesn't strictly need the Gateway (soft/eventually-
+  # consistent DNS reconciliation, no observed race) but shares this wave
+  # rather than getting its own — same "rides along, wave reuse is free"
+  # reasoning gitops repo's bootstrap/README.md uses throughout.
+  - {name: gateway-config, namespace: gateway, chartPath: services/platform/gateway/config, valueFile: values-scaleway.yaml, wave: "2"}
+  - {name: external-dns, namespace: external-dns, chartPath: services/platform/external-dns/chart, valueFile: values-scaleway.yaml, wave: "2", syncWaveLabelPaths: ['external-dns.podLabels.scalepack\.fr/sync-wave']}

--- a/10-cluster/scaleway/platform-apps/values-secrets.yaml
+++ b/10-cluster/scaleway/platform-apps/values-secrets.yaml
@@ -1,0 +1,26 @@
+# OpenBao + ESO — extracted from gitops repo's bootstrap/values.yaml waves
+# 0-1 (infra#84). Every product's own ExternalSecret still depends on this
+# domain being up (dex-secret, external-dns-secret, grafana-secret, etc. —
+# all still in gitops repo's bootstrap, still ESO-managed); this domain now
+# finishes as a Terraform-enforced prerequisite of bootstrap starting at
+# all, instead of being bootstrap's own wave 0-1 — see argocd.tf's
+# wait_platform_apps_healthy null_resource.
+apps:
+  # ── wave 0 ──────────────────────────────────────────────────────────────
+  # openbao + openbao-init share a wave for the same chicken-and-egg reason
+  # gitops repo's bootstrap/README.md documents: openbao's own Application
+  # health never goes Healthy until openbao-init's restore Job has
+  # succeeded, so a later wave for openbao-init could never even start.
+  # openbao-init's own restore credentials (scaleway-s3-credentials) and
+  # openbao's own KMS auto-unseal credentials (openbao-unseal-aws) are
+  # Terraform-managed directly in this repo's main.tf, same as before this
+  # split — unaffected, just no longer racing bootstrap's own apply order.
+  - {name: openbao, namespace: openbao, chartPath: services/platform/openbao/chart, valueFile: values-scaleway.yaml, wave: "0", syncWaveLabelPaths: ['openbao.server.extraLabels.scalepack\.fr/sync-wave']}
+  - {name: openbao-init, namespace: openbao, chartPath: services/platform/openbao/init, valueFile: values-scaleway.yaml, wave: "0"}
+
+  # ── wave 1 ──────────────────────────────────────────────────────────────
+  # external-secrets + secrets-sync (the ClusterSecretStore) share this
+  # wave, one wave after OpenBao — same relative ordering gitops repo's
+  # bootstrap/README.md documents for its own former wave 0/1.
+  - {name: external-secrets, namespace: external-secrets, chartPath: services/platform/external-secrets/chart, valueFile: values-scaleway.yaml, wave: "1", syncWaveLabelPaths: ['external-secrets.podLabels.scalepack\.fr/sync-wave', 'external-secrets.webhook.podLabels.scalepack\.fr/sync-wave', 'external-secrets.certController.podLabels.scalepack\.fr/sync-wave']}
+  - {name: secrets-sync, namespace: secrets-sync, chartPath: services/platform/secrets-sync/config, valueFile: values-scaleway.yaml, wave: "1"}

--- a/10-cluster/scaleway/platform-apps/values.yaml
+++ b/10-cluster/scaleway/platform-apps/values.yaml
@@ -1,0 +1,17 @@
+# Base defaults, always overridden per-domain by argocd.tf's
+# argocd_platform_apps helm_release (which selects one of
+# values-secrets.yaml / values-monitoring.yaml / values-backups.yaml via
+# source.helm.valueFiles, and passes repoURL/revision as Helm parameters —
+# see argocd.tf).
+repoURL: https://github.com/IntegratedDynamic/gitops.git
+revision: main
+
+# Populated per-domain by values-secrets.yaml / values-monitoring.yaml /
+# values-backups.yaml. Each entry: {name, namespace, chartPath, valueFile,
+# wave, skipCrds?, syncWaveLabelPaths?} — same shape as gitops repo's
+# bootstrap/values.yaml scalewayApps list (this chart's templates/apps.yaml
+# renders it the same way). wave here is domain-local (parallel across
+# secrets/monitoring/backups, ordered only within one domain) — NOT the
+# same numbering the gitops repo's bootstrap chart uses for its own
+# remaining apps.
+apps: []

--- a/10-cluster/scaleway/variables.tf
+++ b/10-cluster/scaleway/variables.tf
@@ -39,6 +39,16 @@ variable "gitops_revision" {
   default = "main"
 }
 
+# Revision of THIS repo (infrastructure) ArgoCD's secrets-apps/monitoring-apps/
+# backups-apps Applications pull platform-apps/ from — see argocd.tf's
+# argocd_platform_apps helm_release. Same "override on your own branch to
+# test end-to-end, never merge that change" DevX trick as gitops_revision
+# above; MUST stay "main" on origin/main.
+variable "infra_revision" {
+  type    = string
+  default = "main"
+}
+
 variable "update_kubeconfig" {
   type        = bool
   default     = false

--- a/10-cluster/scaleway/version.tf
+++ b/10-cluster/scaleway/version.tf
@@ -33,10 +33,6 @@ terraform {
       source  = "scaleway/scaleway"
       version = "~> 2.0"
     }
-    local = {
-      source  = "hashicorp/local"
-      version = "~> 2.0"
-    }
     null = {
       source  = "hashicorp/null"
       version = "~> 3.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,37 @@ Two-step, one-time bootstrap:
 
 Same bootstrap pattern as `local/`, but with the Kapsule cluster + node pool (`DEV1-M`, min=0/max=3) instead.
 
+**Secrets/monitoring/backups (infra#84, 2026-08-24):** OpenBao+ESO, monitoring
+(kube-prometheus-stack/loki/tempo/alloy/otel-collector, NOT Grafana — that
+stays in `gitops`), and Velero were extracted from `gitops` repo's
+`bootstrap` app-of-apps into this root's own `platform-apps/` chart —
+three ArgoCD Applications (`secrets-apps`/`monitoring-apps`/`backups-apps`,
+created via `argocd.tf`'s `argocd_platform_apps` helm_release, same
+`argocd-apps` chart mechanism `bootstrap` itself uses) that start in
+parallel with each other and must reach Healthy before `bootstrap`'s own
+Application resource is even created — a real Terraform `depends_on`
+(`null_resource.wait_platform_apps_healthy`, polling via `kubectl` +
+a self-generated kubeconfig), not an ArgoCD sync-wave, since ArgoCD has no
+native ordering primitive across independent top-level Applications (only
+within one parent's own sync — see `platform-apps/README.md`). The actual
+product charts (`services/platform/openbao/chart`, `monitoring/chart`, ...)
+are untouched, still pulled from the `gitops` repo — only which parent
+Application claims them as managed resources moved. Four credentials
+Terraform already originates (thanos/loki/tempo/velero Object Storage
+access keys, from `03-storage/scaleway`) are now written directly as
+`kubernetes_secret` resources in this root's `main.tf` instead of via
+OpenBao+ESO's `ExternalSecret` round-trip — OpenBao (`11-secrets/openbao/managed`)
+still gets the same values written to it independently, staying the
+audited source of truth, but ESO is no longer in the delivery path for
+these four. `monitoring`/`velero` namespaces are Terraform-managed
+(`kubernetes_namespace`, same pattern `openbao`'s namespace already used)
+purely because these Secrets must exist before ArgoCD's own
+`CreateNamespace=true` would otherwise create them — every other extracted
+app's namespace is still ArgoCD-created, unaffected. See
+`platform-apps/README.md` for the full design rationale (including the
+namespace and secret-delivery decisions), and `gitops` repo's
+`bootstrap/README.md` for what changed on that side.
+
 ### `00-foundation/aws/`
 
 The shared org S3 bucket holding **every** root's remote state (built on `terraform-aws-modules/s3-bucket`: versioning, SSE, public-access block, TLS-only). Chicken-and-egg: its own state lives in the bucket it creates (one-time local-state bootstrap — see its README). Also creates the GitHub OIDC provider and the one role, `terraform-state-access` (via `terraform-aws-modules/iam`), every GitHub Actions workflow in this repo assumes — trust scoped to `repo:IntegratedDynamic/infrastructure:*`, policy scoped to exactly S3 list/get/put/delete on the state bucket, nothing else. Wired to CI via `vars.AWS_TERRAFORM_ROLE_ARN`. Applied by an admin (this root creates the very identity CI would otherwise need to apply it). See its README.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,11 +287,15 @@ Two-step, one-time bootstrap:
 
 Same bootstrap pattern as `local/`, but with the Kapsule cluster + node pool (`DEV1-M`, min=0/max=3) instead.
 
-**Secrets/monitoring/backups (infra#84, 2026-08-24):** OpenBao+ESO, monitoring
+**Secrets/monitoring/backups/networking (infra#84, 2026-08-24 + scope
+addition 2026-08-25):** OpenBao+ESO, monitoring
 (kube-prometheus-stack/loki/tempo/alloy/otel-collector, NOT Grafana — that
-stays in `gitops`), and Velero were extracted from `gitops` repo's
-`bootstrap` app-of-apps into this root's own `platform-apps/` chart —
-three ArgoCD Applications (`secrets-apps`/`monitoring-apps`/`backups-apps`,
+stays in `gitops`), Velero, and cluster networking (envoy-gateway,
+cert-manager + its Scaleway DNS01 webhook, external-dns, gateway-config —
+NOT the per-product `*-gateway` HTTPRoute charts like `dex-gateway`, which
+stay in `gitops`) were extracted from `gitops` repo's `bootstrap`
+app-of-apps into this root's own `platform-apps/` chart — four ArgoCD
+Applications (`secrets-apps`/`monitoring-apps`/`backups-apps`/`networking-apps`,
 created via `argocd.tf`'s `argocd_platform_apps` helm_release, same
 `argocd-apps` chart mechanism `bootstrap` itself uses) that start in
 parallel with each other and must reach Healthy before `bootstrap`'s own
@@ -309,7 +313,18 @@ access keys, from `03-storage/scaleway`) are now written directly as
 OpenBao+ESO's `ExternalSecret` round-trip — OpenBao (`11-secrets/openbao/managed`)
 still gets the same values written to it independently, staying the
 audited source of truth, but ESO is no longer in the delivery path for
-these four. `monitoring`/`velero` namespaces are Terraform-managed
+these four. `networking-apps`' own two secrets
+(`cert-manager-webhook-secret`/`external-dns-secret`, the Scaleway
+Domains/DNS API credential) deliberately keep the OpenBao+ESO
+`ExternalSecret` path unchanged instead — Terraform doesn't originate that
+credential the way it does the four Object Storage ones, so there's nothing
+to gain by bypassing ESO there (self-heals against `secrets-apps` the same
+way every other `*-secret` chart in `gitops`'s `bootstrap` already
+tolerates). `gateway-config`'s own dependency on Velero (its cert-restore
+PreSync hook) is left ungated for the same "already self-contained,
+fails open" reason documented in `platform-apps/README.md` — no
+Terraform-level wait between `networking-apps` and `backups-apps`.
+`monitoring`/`velero` namespaces are Terraform-managed
 (`kubernetes_namespace`, same pattern `openbao`'s namespace already used)
 purely because these Secrets must exist before ArgoCD's own
 `CreateNamespace=true` would otherwise create them — every other extracted


### PR DESCRIPTION
## Summary

- Adds `10-cluster/scaleway/platform-apps/` — a small Helm chart rendering four domains' worth of ArgoCD child Applications:
  - **secrets**: OpenBao+ESO
  - **monitoring**: kube-prometheus-stack/loki/tempo/alloy/otel-collector (not Grafana)
  - **backups**: Velero
  - **networking**: envoy-gateway, cert-manager (+ its Scaleway DNS01 webhook), external-dns, gateway-config (not the per-product `*-gateway` HTTPRoute charts, which stay in gitops)

  each domain internally sync-wave-ordered exactly like the `gitops` repo's `bootstrap` chart used to do for these apps.
- `argocd.tf` creates four parent Applications (`secrets-apps`/`monitoring-apps`/`backups-apps`/`networking-apps`) pointing at that chart — same `argocd-apps` Helm mechanism `bootstrap` itself already uses — so they start in parallel with each other.
- A new `null_resource.wait_platform_apps_healthy` polls all four Applications' health via `kubectl` (self-generated kubeconfig, no dependency on the optional `update_kubeconfig` var) and gates `bootstrap`'s own Application creation on it — a real Terraform `depends_on`, since ArgoCD has no native ordering primitive across independent top-level Applications (only within one parent's own sync).
- `main.tf` now writes `thanos-objstore-config`/`loki-s3-credentials`/`tempo-s3-credentials`/`velero-scaleway-credentials` directly as `kubernetes_secret` resources (same pattern already used for OpenBao's own unseal/restore secrets), instead of routing them through OpenBao+ESO's `ExternalSecret` mechanism — Terraform already originates all four via `03-storage/scaleway`. OpenBao still gets the same values independently (`11-secrets/openbao/managed`, unchanged) and stays the audited source of truth.
- `networking-apps`' own two secrets (`cert-manager-webhook-secret`/`external-dns-secret`) deliberately **keep** the OpenBao+ESO `ExternalSecret` path — Terraform doesn't originate that Scaleway Domains/DNS credential the way it does the four Object Storage ones, so there's nothing to gain by bypassing ESO there. No new Terraform-level gating against `backups-apps` either: `gateway-config`'s Velero dependency (its cert-restore PreSync hook) already queries Velero's `Backup`/`Restore` objects directly and fails open — see the issue comment thread for the investigation.
- `monitoring`/`velero` namespaces become Terraform-managed (`kubernetes_namespace`), same pattern `openbao`'s already used, purely because these Secrets must exist before ArgoCD would otherwise create the namespace.
- `CLAUDE.md` and the new chart's own `README.md` document the full design, including the namespace and secret-delivery decisions from infra#84's open questions (both the original scope and the networking scope extension).

Companion `gitops` repo PR: https://github.com/IntegratedDynamic/gitops/pull/48 (trims `bootstrap/values.yaml` accordingly and deletes the four now-redundant `ExternalSecret`-only charts for the Object-Storage-backed secrets).

Part of #84 -- deliberately not closing yet: cluster networking/routing management via Terraform (envoy-gateway/cert-manager/external-dns lifecycle beyond this first extraction) still has real gaps that cost real time in live testing (see this PR's comment thread), so the issue stays open as a checkpoint, not a finish line.

## Validation done

- `terraform fmt`, `terraform validate`: clean.
- `terraform plan` against live state (before the networking-domain commit): 9 to add (exactly the new resources), 0 to destroy. The 2 "in-place update" resources shown (`helm_release.argocd`, `helm_release.argocd_apps`) are pre-existing helm-provider `metadata` recompute noise, not caused by this change.
- **Note found during planning, unrelated to this PR**: the live cluster's `bootstrap` Application is currently pinned to `targetRevision: feature/grafana-internal-dns` instead of `main` (leftover manual test override, per this repo's own "override on your own branch, never merge that" convention). Applying this PR's plan will also revert that pin back to `main` (the var's default) as a side effect — flagging so it's a deliberate choice at apply time, not a surprise.
- `helm lint` + `helm template` on the `platform-apps` chart for all four value files: renders the expected Applications with correct wave numbers.
- Did **not** run `terraform apply` — this reshapes live bootstrap ordering on the homelab cluster, so it should be applied deliberately (and probably validated end-to-end against a fresh cluster boot, not just a live plan) rather than as part of this PR's automation.

## Test plan

- [ ] Merge this PR and the companion `gitops` PR together (or with `infra_revision`/`gitops_revision` pointed at these branches first, to test end-to-end before merging — see each var's own comment for the convention)
- [ ] `terraform apply` `10-cluster/scaleway` and confirm `secrets-apps`/`monitoring-apps`/`backups-apps`/`networking-apps` all go Healthy before `bootstrap`'s Application even appears
- [ ] Confirm OpenBao unseals, ESO's `ClusterSecretStore` goes Ready, and every downstream `*-secret` chart in `gitops`'s `bootstrap` still resolves (including `cert-manager-webhook-secret`/`external-dns-secret`, now in `networking-apps`)
- [ ] Confirm Prometheus/Loki/Tempo/Alloy/otel-collector come up healthy with their Terraform-provisioned Secrets
- [ ] Confirm Velero comes up healthy and Grafana's `grafana-restore-*` PreSync hook still finds a backup to restore from
- [ ] Confirm envoy-gateway/cert-manager/external-dns/gateway-config come up healthy and the shared Gateway/wildcard TLS cert resolve (including a from-backup restore via `gateway-config`'s cert-restore hook)
- [ ] Decide/confirm the `bootstrap` revision-pin note above before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yyUsur4a2AiUNqyJiTo4Q
