### PR TITLE
feat: finish extracting bootstrap into a Terraform-managed DAG (infra#84)

### DIFF
--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -349,11 +349,10 @@ resource "helm_release" "argocd_apps" {
   # exceed 5 minutes.
   timeout = 1800
 
-  # wait_platform_apps_healthy (below) is the real Terraform-enforced
+  # module.wait_all_domains_healthy (below) is the real Terraform-enforced
   # prerequisite: bootstrap's Application must not even be created until
-  # secrets-apps/monitoring-apps/backups-apps/networking-apps are Healthy —
-  # see platform-apps/README.md.
-  depends_on = [helm_release.argocd, kubernetes_job_v1.wait_platform_apps_healthy]
+  # every platform domain is Healthy — see platform-apps/README.md.
+  depends_on = [helm_release.argocd, module.wait_all_domains_healthy]
 
   values = [<<EOF
 applications:
@@ -364,7 +363,8 @@ applications:
     # before removing this object itself, instead of the default "just
     # forget about it, leave whatever it deployed running" behavior.
     # Confirmed live (2026-08-25): without this, a `terraform destroy`
-    # tears down helm_release.argocd_apps/argocd_platform_apps/argocd in
+    # tears down helm_release.argocd_apps/argocd (and, before this was
+    # split per-domain, the old combined argocd_platform_apps) in
     # ~13s combined -- nowhere near enough for anything to gracefully
     # shut down -- leaving e.g. Velero's own pod orphaned right before
     # kubernetes_namespace.velero's cascade delete races its controller's
@@ -402,64 +402,60 @@ EOF
   ]
 }
 
-# ── Secrets/monitoring/backups/networking, extracted from gitops repo (infra#84) ───
+# ── Secrets/monitoring/backups/networking/wireguard, extracted from gitops repo (infra#84 + follow-up) ───
 #
-# Four parent Applications (secrets-apps/monitoring-apps/backups-apps/
-# networking-apps), each pointing at this repo's own platform-apps/ chart
-# (not gitops) for their OWN list of child Applications — see that chart's
-# README.md for the full "why" (ArgoCD sync-wave only orders resources
-# within one parent Application's own sync, so separate parents is what
-# actually lets these domains start in parallel with each other while
-# keeping each domain's own real intra-domain ordering, e.g.
-# kube-prometheus-stack-crds before kube-prometheus-stack, or
-# envoy-gateway/cert-manager before gateway-config). The child Applications' own charts
+# Each domain below is its OWN helm_release (one Application each), instead
+# of the single combined helm_release.argocd_platform_apps this used to be
+# -- required so Terraform can express real depends_on edges BETWEEN
+# domains (Helm gives no ordering guarantee across sibling resources of one
+# release, which is exactly what let secrets-apps/networking-apps race each
+# other's teardown before this split -- see platform-apps/README.md's
+# "Generalizing the finalizer-race fix" section). Each still points at this
+# repo's own platform-apps/ chart (not gitops) for its OWN list of child
+# Applications -- see that chart's README.md for the full "why" on the
+# chart-level mechanics (ArgoCD sync-wave only orders resources within one
+# parent Application's own sync). The child Applications' own charts
 # (services/platform/openbao/chart, monitoring/chart, ...) are untouched,
 # still pulled from the gitops repo, same as before this split — only which
 # parent Application claims them as managed resources changed.
-resource "helm_release" "argocd_platform_apps" {
-  name      = "argocd-platform-apps"
+#
+# Common shape every one of these helm_release resources shares: same
+# repository/chart/version (upstream argoproj argocd-apps, renders one
+# Application per values file's `applications:` key), same timeout = 1800
+# (uninstall must wait for ArgoCD to cascade-delete the whole child-tree via
+# resources-finalizer.argocd.argoproj.io -- confirmed live 2026-08-25 this
+# exceeds 5 minutes), same finalizers/syncPolicy shape. Only name,
+# valueFiles, and depends_on vary per domain -- documented per-resource
+# below rather than factored into a module, since Terraform's helm_release
+# doesn't support a for_each-friendly way to vary depends_on per instance
+# without losing the explicit, greppable per-domain comments this file
+# already relies on elsewhere.
+locals {
+  # Shared skeleton for every domain's single-Application `applications:`
+  # values block -- only the domain name + valueFile actually change.
+  platform_apps_source_repo = "https://github.com/IntegratedDynamic/infrastructure.git"
+}
+
+resource "helm_release" "secrets_apps" {
+  name      = "argocd-secrets-apps"
   namespace = "argocd"
 
   repository = "https://argoproj.github.io/argo-helm"
   chart      = "argocd-apps"
   version    = "2.0.4"
 
-  # Applies to both install AND uninstall -- default (300s) isn't enough
-  # for uninstall, since each domain's own resources-finalizer.argocd.argoproj.io
-  # (see values below) now makes deleting these four Applications wait for
-  # ArgoCD to cascade-delete their entire child-Application trees first.
-  # Same timeout as kubernetes_job_v1.wait_platform_apps_healthy's own
-  # budget (below) -- confirmed live (2026-08-25) that this exceeded 5
-  # minutes and made this resource's own destroy time out.
   timeout = 1800
 
-  # scaleway_s3_credentials/openbao_unseal_aws included here too (not just
-  # the four secrets this split introduced): without them, nothing ordered
-  # kubernetes_namespace.openbao's destroy after this release's own --
-  # confirmed live (2026-08-25) that ArgoCD's openbao Application (with
-  # selfHeal: true, and now resources-finalizer.argocd.argoproj.io) was
-  # still actively retrying "create content in namespace openbao" while
-  # Terraform was independently, concurrently deleting that same namespace
-  # directly -- every retry failing with "namespace is being terminated",
-  # forever, since nothing told ArgoCD's own graceful teardown to finish
-  # first. monitoring/velero's namespaces never had this problem only by
-  # accident, via their own four secrets already being listed here.
-  #
-  # null_resource.velero_namespace_predelete_cleanup (main.tf) is included
-  # here too, for the DESTROY direction specifically: "A depends_on B"
-  # means A destroys before B, so listing that null_resource here makes
-  # THIS release destroy (and therefore Velero's controller die) BEFORE
-  # that cleanup's local-exec runs -- see that resource's own comment in
-  # main.tf for the two earlier, wrong attempts at this ordering.
+  # scaleway_s3_credentials/openbao_unseal_aws: without them, nothing
+  # ordered kubernetes_namespace.openbao's destroy after this release's own
+  # -- confirmed live (2026-08-25) that ArgoCD's openbao Application (with
+  # selfHeal: true, and resources-finalizer.argocd.argoproj.io) was still
+  # actively retrying "create content in namespace openbao" while Terraform
+  # was independently, concurrently deleting that same namespace directly.
   depends_on = [
     helm_release.argocd,
     kubernetes_secret.scaleway_s3_credentials,
     kubernetes_secret.openbao_unseal_aws,
-    kubernetes_secret.thanos_objstore_config,
-    kubernetes_secret.loki_s3_credentials,
-    kubernetes_secret.tempo_s3_credentials,
-    kubernetes_secret.velero_scaleway_credentials,
-    null_resource.velero_namespace_predelete_cleanup,
   ]
 
   values = [<<EOF
@@ -473,7 +469,7 @@ applications:
       - resources-finalizer.argocd.argoproj.io
     project: default
     source:
-      repoURL: https://github.com/IntegratedDynamic/infrastructure.git
+      repoURL: ${local.platform_apps_source_repo}
       targetRevision: ${var.infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
@@ -493,7 +489,103 @@ applications:
         selfHeal: true
       syncOptions:
         - CreateNamespace=true
+EOF
+  ]
+}
 
+# THE FIX for the ESO/ExternalSecret cross-domain finalizer race (confirmed
+# live 2026-08-25, infra#84's own follow-up comment thread), generalized:
+# every ExternalSecret across every platform domain (dex-secret,
+# grafana-secret, wireguard-secret, argo-workflows-secret,
+# argocd-config-secret, cert-manager-webhook-secret, external-dns-secret)
+# lives in ONE dedicated domain here, instead of being bundled into each
+# product's own domain. Each carries a
+# externalsecrets.external-secrets.io/externalsecret-cleanup finalizer that
+# only ESO's own controller (secrets-apps domain) ever removes -- before
+# this domain existed, cert-manager-webhook-secret/external-dns-secret lived
+# directly in networking-apps, which raced secrets-apps' own teardown (both
+# were keys of one shared helm_release) and could strand that finalizer,
+# previously requiring a manual kubectl patch.
+#
+# Centralizing every ExternalSecret here, with this release depending on
+# secrets-apps, means EVERY product domain gets the same guarantee via the
+# same single edge ("A depends_on B" => A destroys before B): this release
+# (and every ExternalSecret it owns) is guaranteed to finish destroying
+# before secrets-apps' own release -- and therefore ESO's own controller --
+# even starts tearing down. No product domain needs its own direct
+# dependency on secrets-apps for this reason anymore; they depend on THIS
+# domain instead (see e.g. helm_release.networking_apps/wireguard_apps
+# below), which is what actually holds the ExternalSecret they consume.
+resource "helm_release" "eso_data_apps" {
+  name      = "argocd-eso-data-apps"
+  namespace = "argocd"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.4"
+
+  timeout = 1800
+
+  depends_on = [
+    helm_release.argocd,
+    helm_release.secrets_apps,
+  ]
+
+  values = [<<EOF
+applications:
+  eso-data-apps:
+    namespace: argocd
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    project: default
+    source:
+      repoURL: ${local.platform_apps_source_repo}
+      targetRevision: ${var.infra_revision}
+      path: 10-cluster/scaleway/platform-apps
+      helm:
+        valueFiles:
+          - values-eso-data.yaml
+        parameters:
+          - name: revision
+            value: ${var.gitops_revision}
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: argocd
+    syncPolicy:
+      retry:
+        limit: 10
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+EOF
+  ]
+}
+
+resource "helm_release" "monitoring_apps" {
+  name      = "argocd-monitoring-apps"
+  namespace = "argocd"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.4"
+
+  timeout = 1800
+
+  # No ESO ExternalSecret in this domain (thanos/loki/tempo credentials are
+  # Terraform-originated Secrets, see platform-apps/README.md's
+  # "secret-delivery pattern") -- no ordering dependency on secrets-apps
+  # needed, stays fully parallel with it, same as before this split.
+  depends_on = [
+    helm_release.argocd,
+    kubernetes_secret.thanos_objstore_config,
+    kubernetes_secret.loki_s3_credentials,
+    kubernetes_secret.tempo_s3_credentials,
+  ]
+
+  values = [<<EOF
+applications:
   monitoring-apps:
     namespace: argocd
     # Cascade-deletes this domain's own child Applications
@@ -503,7 +595,7 @@ applications:
       - resources-finalizer.argocd.argoproj.io
     project: default
     source:
-      repoURL: https://github.com/IntegratedDynamic/infrastructure.git
+      repoURL: ${local.platform_apps_source_repo}
       targetRevision: ${var.infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
@@ -523,7 +615,35 @@ applications:
         selfHeal: true
       syncOptions:
         - CreateNamespace=true
+EOF
+  ]
+}
 
+resource "helm_release" "backups_apps" {
+  name      = "argocd-backups-apps"
+  namespace = "argocd"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.4"
+
+  timeout = 1800
+
+  # No ESO ExternalSecret in this domain either (velero's credential is also
+  # Terraform-originated). null_resource.velero_namespace_predelete_cleanup
+  # (main.tf) stays listed here specifically, for the DESTROY direction: "A
+  # depends_on B" means A destroys before B, so listing that null_resource
+  # here makes THIS release destroy (and therefore Velero's controller die)
+  # BEFORE that cleanup's local-exec runs -- see that resource's own comment
+  # in main.tf for the two earlier, wrong attempts at this ordering.
+  depends_on = [
+    helm_release.argocd,
+    kubernetes_secret.velero_scaleway_credentials,
+    null_resource.velero_namespace_predelete_cleanup,
+  ]
+
+  values = [<<EOF
+applications:
   backups-apps:
     namespace: argocd
     # Cascade-deletes this domain's own child Application (velero) before
@@ -535,7 +655,7 @@ applications:
       - resources-finalizer.argocd.argoproj.io
     project: default
     source:
-      repoURL: https://github.com/IntegratedDynamic/infrastructure.git
+      repoURL: ${local.platform_apps_source_repo}
       targetRevision: ${var.infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
@@ -555,7 +675,36 @@ applications:
         selfHeal: true
       syncOptions:
         - CreateNamespace=true
+EOF
+  ]
+}
 
+resource "helm_release" "networking_apps" {
+  name      = "argocd-networking-apps"
+  namespace = "argocd"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.4"
+
+  timeout = 1800
+
+  # cert-manager-webhook-secret/external-dns-secret used to live directly in
+  # this domain -- moved to eso-data-apps (see that resource's own comment
+  # for the original finalizer-race bug this fixed). envoy-gateway/
+  # cert-manager/external-dns still consume those Secrets at runtime, just
+  # from a different owning Application now -- depending on eso-data-apps
+  # keeps their creation roughly ordered ahead of this domain's own pods
+  # (same "briefly races, self-heals" tolerance every ESO consumer here
+  # already accepts, not a hard requirement now that the finalizer risk
+  # itself is fully owned by eso-data-apps' own depends_on).
+  depends_on = [
+    helm_release.argocd,
+    helm_release.eso_data_apps,
+  ]
+
+  values = [<<EOF
+applications:
   networking-apps:
     namespace: argocd
     # Cascade-deletes this domain's own child Applications (envoy-gateway,
@@ -565,12 +714,64 @@ applications:
       - resources-finalizer.argocd.argoproj.io
     project: default
     source:
-      repoURL: https://github.com/IntegratedDynamic/infrastructure.git
+      repoURL: ${local.platform_apps_source_repo}
       targetRevision: ${var.infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
         valueFiles:
           - values-networking.yaml
+        parameters:
+          - name: revision
+            value: ${var.gitops_revision}
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: argocd
+    syncPolicy:
+      retry:
+        limit: 10
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+EOF
+  ]
+}
+
+resource "helm_release" "wireguard_apps" {
+  name      = "argocd-wireguard-apps"
+  namespace = "argocd"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.4"
+
+  timeout = 1800
+
+  # wireguard-secret itself now lives in eso-data-apps (see that resource's
+  # own comment) -- wireguard-config just consumes the Secret it
+  # materializes. No HTTPRoute in this domain (wireguard-config has no
+  # Gateway API dependency), so unlike every HTTPRoute-bearing domain added
+  # after this one, no wait on networking-apps' CRDs is needed here.
+  depends_on = [
+    helm_release.argocd,
+    helm_release.eso_data_apps,
+  ]
+
+  values = [<<EOF
+applications:
+  wireguard-apps:
+    namespace: argocd
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    project: default
+    source:
+      repoURL: ${local.platform_apps_source_repo}
+      targetRevision: ${var.infra_revision}
+      path: 10-cluster/scaleway/platform-apps
+      helm:
+        valueFiles:
+          - values-wireguard.yaml
         parameters:
           - name: revision
             value: ${var.gitops_revision}
@@ -652,111 +853,386 @@ resource "kubernetes_role_binding" "wait_platform_apps" {
   }
 }
 
-# The Terraform-enforced prerequisite itself: secrets-apps/monitoring-apps/
-# backups-apps/networking-apps must all reach Healthy before bootstrap's own
-# Application resource is even created (see that resource's depends_on
-# above) — ArgoCD has no native way to express "wait for these independent
-# top-level Applications" (sync-wave doesn't cross Application boundaries),
-# so this is enforced as a real Terraform apply-order dependency instead.
-# `wait_for_completion` makes Terraform itself block on this Job's Complete
-# condition — no manual polling of the Job from Terraform's side needed.
-# Checks all four Applications together on each iteration (not one at a
-# time with its own budget each) since they sync in parallel — a
-# sequential per-app budget would only be correct if they synced one after
-# another, which is exactly what this whole mechanism exists to avoid.
-resource "kubernetes_job_v1" "wait_platform_apps_healthy" {
-  metadata {
-    name      = "wait-platform-apps-healthy"
-    namespace = "argocd"
-  }
+# ── Tier 1: dex/argocd-config/grafana, extracted from gitops repo (infra#84 follow-up) ───
+#
+# Each of these three domains shares the identical dependency profile:
+# eso-data-apps (for its own consumed Secret) + networking-apps' Gateway API
+# CRDs (for its own *-gateway HTTPRoute) -- but each stays its OWN
+# helm_release/Application rather than one bundled domain, since
+# argo-workflows-apps (Tier 2, below) needs to health-wait on dex
+# specifically, not a bundle diluted by argocd-config/grafana's unrelated
+# health.
+module "wait_networking_healthy" {
+  source = "./modules/wait-argocd-apps-healthy"
 
-  spec {
-    # Overall budget for all four Applications combined — generous for the
-    # same "cluster boot, not steady-state" reason bootstrap's own
-    # syncPolicy.retry.limit comment gives. Bumped 900 -> 1800 (2026-08-25):
-    # confirmed live on a from-scratch cluster boot that a healthy run can
-    # itself take 7+ minutes once ArgoCD/DNS warm-up variance is factored
-    # in, and the first-ever timing run hit the original 900s budget
-    # outright -- 1800s is a deliberately generous placeholder until this
-    # is measured more precisely across a few more boots.
-    active_deadline_seconds = 1800
-    backoff_limit           = 0
-
-    template {
-      metadata {
-        labels = {
-          "app.kubernetes.io/name" = "wait-platform-apps-healthy"
-        }
-      }
-
-      spec {
-        service_account_name = kubernetes_service_account.wait_platform_apps.metadata[0].name
-        restart_policy       = "Never"
-
-        container {
-          name = "wait"
-          # Same image gitops repo's services/platform/gateway/config
-          # (cert-restore-job.yaml) already uses for the identical
-          # "kubectl + shell" shape — one fewer image to pull/trust.
-          image = "alpine/kubectl:1.35.3"
-
-          command = ["sh", "-c", <<-EOT
-            set -eu
-            apps="secrets-apps monitoring-apps backups-apps networking-apps"
-            while true; do
-              all_healthy=true
-              for app in $apps; do
-                sync=$(kubectl get application "$app" -n argocd -o jsonpath='{.status.sync.status}' 2>/dev/null || true)
-                health=$(kubectl get application "$app" -n argocd -o jsonpath='{.status.health.status}' 2>/dev/null || true)
-                # health.status alone isn't enough: a brand-new Application
-                # with zero resources synced yet trivially reports Healthy
-                # (nothing exists yet to BE unhealthy) well before its own
-                # first sync even starts. Confirmed live (2026-08-25): this
-                # Job completed in 17s claiming all four domains healthy,
-                # while backups-apps' own child (velero) hadn't even been
-                # created yet -- checking sync=Synced too is what
-                # wait_bootstrap_healthy already got right below; this Job
-                # just needed the same fix.
-                if [ "$sync" != "Synced" ] || [ "$health" != "Healthy" ]; then
-                  all_healthy=false
-                  echo "Application/$app: sync=$${sync:-<none yet>} health=$${health:-<none yet>}"
-                fi
-              done
-              if [ "$all_healthy" = "true" ]; then
-                echo "All platform apps are Synced and Healthy."
-                exit 0
-              fi
-              sleep 5
-            done
-          EOT
-          ]
-
-          # Forces a fresh Job (Kubernetes rejects in-place updates to a
-          # Job's pod template — Terraform replaces the whole resource
-          # instead) whenever the platform apps are actually re-applied,
-          # same "re-run the wait on redeploy" behavior the previous
-          # null_resource got from its own `triggers` block.
-          env {
-            name  = "PLATFORM_APPS_REVISION"
-            value = helm_release.argocd_platform_apps.metadata.revision
-          }
-        }
-      }
-    }
-  }
-
-  wait_for_completion = true
-
-  # Must stay above active_deadline_seconds above (30m) -- this is
-  # Terraform's own wait on the Job resource itself, so a shorter value
-  # here would make Terraform give up before the Job's own budget even
-  # runs out.
-  timeouts {
-    create = "35m"
-  }
+  job_name             = "wait-networking-healthy"
+  app_names            = ["networking-apps"]
+  service_account_name = kubernetes_service_account.wait_platform_apps.metadata[0].name
+  revision_trigger     = helm_release.networking_apps.metadata.revision
 
   depends_on = [
-    helm_release.argocd_platform_apps,
+    helm_release.networking_apps,
+    kubernetes_role_binding.wait_platform_apps,
+  ]
+}
+
+resource "helm_release" "dex_apps" {
+  name      = "argocd-dex-apps"
+  namespace = "argocd"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.4"
+
+  timeout = 1800
+
+  depends_on = [
+    helm_release.argocd,
+    helm_release.eso_data_apps,
+    module.wait_networking_healthy,
+  ]
+
+  values = [<<EOF
+applications:
+  dex-apps:
+    namespace: argocd
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    project: default
+    source:
+      repoURL: ${local.platform_apps_source_repo}
+      targetRevision: ${var.infra_revision}
+      path: 10-cluster/scaleway/platform-apps
+      helm:
+        valueFiles:
+          - values-dex.yaml
+        parameters:
+          - name: revision
+            value: ${var.gitops_revision}
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: argocd
+    syncPolicy:
+      retry:
+        limit: 10
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+EOF
+  ]
+}
+
+resource "helm_release" "argocd_config_apps" {
+  name      = "argocd-argocd-config-apps"
+  namespace = "argocd"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.4"
+
+  timeout = 1800
+
+  depends_on = [
+    helm_release.argocd,
+    helm_release.eso_data_apps,
+    module.wait_networking_healthy,
+  ]
+
+  values = [<<EOF
+applications:
+  argocd-config-apps:
+    namespace: argocd
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    project: default
+    source:
+      repoURL: ${local.platform_apps_source_repo}
+      targetRevision: ${var.infra_revision}
+      path: 10-cluster/scaleway/platform-apps
+      helm:
+        valueFiles:
+          - values-argocd-config.yaml
+        parameters:
+          - name: revision
+            value: ${var.gitops_revision}
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: argocd
+    syncPolicy:
+      retry:
+        limit: 10
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+EOF
+  ]
+}
+
+resource "helm_release" "grafana_apps" {
+  name      = "argocd-grafana-apps"
+  namespace = "argocd"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.4"
+
+  timeout = 1800
+
+  depends_on = [
+    helm_release.argocd,
+    helm_release.eso_data_apps,
+    module.wait_networking_healthy,
+  ]
+
+  values = [<<EOF
+applications:
+  grafana-apps:
+    namespace: argocd
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    project: default
+    source:
+      repoURL: ${local.platform_apps_source_repo}
+      targetRevision: ${var.infra_revision}
+      path: 10-cluster/scaleway/platform-apps
+      helm:
+        valueFiles:
+          - values-grafana.yaml
+        parameters:
+          - name: revision
+            value: ${var.gitops_revision}
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: argocd
+    syncPolicy:
+      retry:
+        limit: 10
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+EOF
+  ]
+}
+
+# ── Tier 2: argo-workflows, extracted from gitops repo (infra#84 follow-up) ───
+#
+# argo-workflows/chart eager-dials Dex's OIDC issuer at pod startup and
+# crash-loops if Dex isn't reachable -- a real hard dependency, unlike ESO's
+# self-heal tolerance. Waits on dex-apps specifically (not a bundle) for
+# exactly this reason -- see values-dex.yaml's own header comment for why
+# dex-apps stayed its own domain.
+module "wait_dex_healthy" {
+  source = "./modules/wait-argocd-apps-healthy"
+
+  job_name             = "wait-dex-healthy"
+  app_names            = ["dex-apps"]
+  service_account_name = kubernetes_service_account.wait_platform_apps.metadata[0].name
+  revision_trigger     = helm_release.dex_apps.metadata.revision
+
+  depends_on = [
+    helm_release.dex_apps,
+    kubernetes_role_binding.wait_platform_apps,
+  ]
+}
+
+resource "helm_release" "argo_workflows_apps" {
+  name      = "argocd-argo-workflows-apps"
+  namespace = "argocd"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.4"
+
+  timeout = 1800
+
+  depends_on = [
+    helm_release.argocd,
+    helm_release.eso_data_apps,
+    module.wait_dex_healthy,
+  ]
+
+  values = [<<EOF
+applications:
+  argo-workflows-apps:
+    namespace: argocd
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    project: default
+    source:
+      repoURL: ${local.platform_apps_source_repo}
+      targetRevision: ${var.infra_revision}
+      path: 10-cluster/scaleway/platform-apps
+      helm:
+        valueFiles:
+          - values-argo-workflows.yaml
+        parameters:
+          - name: revision
+            value: ${var.gitops_revision}
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: argocd
+    syncPolicy:
+      retry:
+        limit: 10
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+EOF
+  ]
+}
+
+# ── Tier 3: terraform-apply, extracted from gitops repo (infra#84 follow-up) ───
+#
+# grafana-managed's preflight calls Grafana's live HTTP API directly, and
+# the PostSync initial-run-workflow hook needs argo-workflows' own
+# WorkflowTemplate/CRDs already installed -- hard dependency on BOTH
+# argo-workflows-apps AND grafana-apps being Healthy, not just Synced.
+module "wait_argo_workflows_and_grafana_healthy" {
+  source = "./modules/wait-argocd-apps-healthy"
+
+  job_name  = "wait-argo-workflows-and-grafana-healthy"
+  app_names = ["argo-workflows-apps", "grafana-apps"]
+
+  service_account_name = kubernetes_service_account.wait_platform_apps.metadata[0].name
+  revision_trigger = join(",", [
+    helm_release.argo_workflows_apps.metadata.revision,
+    helm_release.grafana_apps.metadata.revision,
+  ])
+
+  depends_on = [
+    helm_release.argo_workflows_apps,
+    helm_release.grafana_apps,
+    kubernetes_role_binding.wait_platform_apps,
+  ]
+}
+
+resource "helm_release" "terraform_apply_apps" {
+  name      = "argocd-terraform-apply-apps"
+  namespace = "argocd"
+
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argocd-apps"
+  version    = "2.0.4"
+
+  timeout = 1800
+
+  depends_on = [
+    helm_release.argocd,
+    helm_release.eso_data_apps,
+    module.wait_argo_workflows_and_grafana_healthy,
+  ]
+
+  values = [<<EOF
+applications:
+  terraform-apply-apps:
+    namespace: argocd
+    finalizers:
+      - resources-finalizer.argocd.argoproj.io
+    project: default
+    source:
+      repoURL: ${local.platform_apps_source_repo}
+      targetRevision: ${var.infra_revision}
+      path: 10-cluster/scaleway/platform-apps
+      helm:
+        valueFiles:
+          - values-terraform-apply.yaml
+        parameters:
+          - name: revision
+            value: ${var.gitops_revision}
+    destination:
+      server: https://kubernetes.default.svc
+      namespace: argocd
+    syncPolicy:
+      retry:
+        limit: 10
+      automated:
+        prune: true
+        selfHeal: true
+      syncOptions:
+        - CreateNamespace=true
+EOF
+  ]
+}
+
+# The Terraform-enforced prerequisite itself: every platform domain must
+# reach Healthy before bootstrap's own Application resource is even created
+# (see that resource's depends_on above) — ArgoCD has no native way to
+# express "wait for these independent top-level Applications" (sync-wave
+# doesn't cross Application boundaries), so this is enforced as a real
+# Terraform apply-order dependency instead. Factored into the
+# wait-argocd-apps-healthy module (infra#84 follow-up) once the platform-apps
+# DAG grew past the original flat "four domains in parallel, then bootstrap"
+# shape — this is now the FINAL gate in that DAG, not the only one; see
+# platform-apps/README.md for the full DAG and the other, narrower gates
+# (module "wait_networking_healthy", "wait_dex_healthy", etc.) that sit
+# between individual domains. Named for what it now actually checks — every
+# domain, not just the original four "platform apps".
+#
+# app_names lists every domain by name, not just the DAG's leaves: checking
+# leaves alone would work (a leaf can't be Healthy without its own
+# ancestors having already succeeded), but listing everything explicitly is
+# the same defensive, easy-to-audit style the original four-app version of
+# this check already used — a leaf-only list would be a subtler invariant
+# to keep correct as domains are added/removed.
+module "wait_all_domains_healthy" {
+  source = "./modules/wait-argocd-apps-healthy"
+
+  job_name = "wait-all-domains-healthy"
+  app_names = [
+    "secrets-apps",
+    "eso-data-apps",
+    "monitoring-apps",
+    "backups-apps",
+    "networking-apps",
+    "wireguard-apps",
+    "dex-apps",
+    "argocd-config-apps",
+    "grafana-apps",
+    "argo-workflows-apps",
+    "terraform-apply-apps",
+  ]
+  service_account_name = kubernetes_service_account.wait_platform_apps.metadata[0].name
+
+  # Forces a fresh Job whenever ANY watched domain is redeployed, and
+  # supplies the implicit Terraform dependency on all of them — see the
+  # module's own revision_trigger description. Joining every domain's own
+  # revision means a change to any one of them alone is enough to trigger a
+  # fresh Job, same "re-run the wait on redeploy" behavior the original
+  # single-domain PLATFORM_APPS_REVISION env var had.
+  revision_trigger = join(",", [
+    helm_release.secrets_apps.metadata.revision,
+    helm_release.eso_data_apps.metadata.revision,
+    helm_release.monitoring_apps.metadata.revision,
+    helm_release.backups_apps.metadata.revision,
+    helm_release.networking_apps.metadata.revision,
+    helm_release.wireguard_apps.metadata.revision,
+    helm_release.dex_apps.metadata.revision,
+    helm_release.argocd_config_apps.metadata.revision,
+    helm_release.grafana_apps.metadata.revision,
+    helm_release.argo_workflows_apps.metadata.revision,
+    helm_release.terraform_apply_apps.metadata.revision,
+  ])
+
+  depends_on = [
+    helm_release.secrets_apps,
+    helm_release.eso_data_apps,
+    helm_release.monitoring_apps,
+    helm_release.backups_apps,
+    helm_release.networking_apps,
+    helm_release.wireguard_apps,
+    helm_release.dex_apps,
+    helm_release.argocd_config_apps,
+    helm_release.grafana_apps,
+    helm_release.argo_workflows_apps,
+    helm_release.terraform_apply_apps,
     kubernetes_role_binding.wait_platform_apps,
   ]
 }

--- a/10-cluster/scaleway/modules/wait-argocd-apps-healthy/main.tf
+++ b/10-cluster/scaleway/modules/wait-argocd-apps-healthy/main.tf
@@ -1,0 +1,81 @@
+# Factored out of argocd.tf's original wait_platform_apps_healthy/
+# wait_bootstrap_healthy resources (infra#84) once the platform-apps DAG grew
+# past the original flat "4 domains in parallel, then bootstrap" shape --
+# every edge in that DAG needs the identical kubectl-poll-until-healthy
+# pattern, just watching a different set of Application names. See
+# 10-cluster/scaleway/platform-apps/README.md for why this exists at all
+# (ArgoCD has no native way to gate one top-level Application's sync on
+# another's health).
+resource "kubernetes_job_v1" "wait" {
+  metadata {
+    name      = var.job_name
+    namespace = "argocd"
+  }
+
+  spec {
+    active_deadline_seconds = var.active_deadline_seconds
+    backoff_limit           = 0
+
+    template {
+      metadata {
+        labels = {
+          "app.kubernetes.io/name" = var.job_name
+        }
+      }
+
+      spec {
+        service_account_name = var.service_account_name
+        restart_policy       = "Never"
+
+        container {
+          name  = "wait"
+          image = "alpine/kubectl:1.35.3"
+
+          command = ["sh", "-c", <<-EOT
+            set -eu
+            apps="${join(" ", var.app_names)}"
+            while true; do
+              all_healthy=true
+              for app in $apps; do
+                sync=$(kubectl get application "$app" -n argocd -o jsonpath='{.status.sync.status}' 2>/dev/null || true)
+                health=$(kubectl get application "$app" -n argocd -o jsonpath='{.status.health.status}' 2>/dev/null || true)
+                # health.status alone isn't enough -- a brand-new Application
+                # with zero resources synced yet trivially reports Healthy.
+                # See argocd.tf's original wait_platform_apps_healthy comment
+                # for the confirmed-live incident this guards against.
+                if [ "$sync" != "Synced" ] || [ "$health" != "Healthy" ]; then
+                  all_healthy=false
+                  echo "Application/$app: sync=$${sync:-<none yet>} health=$${health:-<none yet>}"
+                fi
+              done
+              if [ "$all_healthy" = "true" ]; then
+                echo "All watched apps are Synced and Healthy."
+                exit 0
+              fi
+              sleep 5
+            done
+          EOT
+          ]
+
+          # Forces a fresh Job (Kubernetes rejects in-place updates to a
+          # Job's pod template) whenever whatever this gate watches actually
+          # redeploys, and supplies the implicit Terraform dependency on it --
+          # see this variable's own description.
+          env {
+            name  = "REVISION_TRIGGER"
+            value = var.revision_trigger
+          }
+        }
+      }
+    }
+  }
+
+  wait_for_completion = true
+
+  # Must stay above active_deadline_seconds -- this is Terraform's own wait
+  # on the Job resource itself, so a shorter value here would make Terraform
+  # give up before the Job's own budget even runs out.
+  timeouts {
+    create = var.create_timeout
+  }
+}

--- a/10-cluster/scaleway/modules/wait-argocd-apps-healthy/variables.tf
+++ b/10-cluster/scaleway/modules/wait-argocd-apps-healthy/variables.tf
@@ -1,0 +1,37 @@
+variable "job_name" {
+  description = "Name for the Kubernetes Job (must be a valid Kubernetes resource name)."
+  type        = string
+}
+
+variable "app_names" {
+  description = "ArgoCD Application names (in the argocd namespace) this Job polls until every one reports sync=Synced AND health=Healthy."
+  type        = list(string)
+}
+
+variable "service_account_name" {
+  description = "ServiceAccount (in the argocd namespace) with get/list on the Applications resource — see argocd.tf's kubernetes_service_account.wait_platform_apps, shared by every instance of this module."
+  type        = string
+}
+
+variable "revision_trigger" {
+  description = <<-EOT
+    Opaque value written into the Job's pod env (e.g. a helm_release's own
+    .metadata.revision). Forces a fresh Job whenever the thing this gate
+    watches is redeployed, AND supplies Terraform's implicit dependency on
+    whatever produced this value -- same trick argocd.tf's own
+    PLATFORM_APPS_REVISION/BOOTSTRAP_REVISION env vars already use.
+  EOT
+  type        = string
+}
+
+variable "active_deadline_seconds" {
+  description = "Overall polling budget for the Job itself, in seconds."
+  type        = number
+  default     = 1800
+}
+
+variable "create_timeout" {
+  description = "Terraform's own wait on the Job's Complete condition. Must stay above active_deadline_seconds, same reasoning as the pre-module wait jobs' own timeouts block."
+  type        = string
+  default     = "35m"
+}

--- a/10-cluster/scaleway/platform-apps/README.md
+++ b/10-cluster/scaleway/platform-apps/README.md
@@ -139,3 +139,111 @@ Object Storage keys, which come straight from this same repo's
 credential Terraform has no more direct a line to than ESO already does, so
 this domain deliberately keeps the existing mechanism rather than applying
 the direct-`kubernetes_secret` pattern uniformly.
+
+## Finishing the migration + generalizing the finalizer-race fix (infra#84 follow-up, 2026-08-25)
+
+The four domains above left one known bug: `networking-apps`' own
+`cert-manager-webhook-secret`/`external-dns-secret` are ESO
+`ExternalSecret`s, carrying a `externalsecrets.external-secrets.io/externalsecret-cleanup`
+finalizer that only ESO's own controller (`secrets-apps` domain) ever
+removes. Since `secrets-apps` and `networking-apps` were two keys of the
+*same* `helm_release.argocd_platform_apps`, Helm tore both down in parallel
+on `destroy` with no ordering between them — ESO's pod could die before it
+ever processed this finalizer removal, stranding the object (confirmed live
+2026-08-25, previously required a manual `kubectl patch`).
+
+This follow-up did two things at once: finished migrating every remaining
+`gitops` repo `bootstrap` app into this same Terraform-managed pattern (so
+only `demo` is left there), and fixed the finalizer race structurally in a
+way that covers every domain this added, not just `networking-apps`.
+
+**Every domain is now its own `helm_release`**, not a shared one. This is
+the mechanical prerequisite for everything below: Helm gives no ordering
+guarantee across sibling resources of one release (which is exactly what
+let `secrets-apps`/`networking-apps` race each other's teardown), but
+Terraform's own `depends_on` between separate `helm_release` resources is a
+real graph edge — "A depends_on B" means A is created after B and destroyed
+before B, so a domain listed in a `depends_on` is *guaranteed* to still be
+alive throughout everything that depends on it.
+
+**Every `ExternalSecret` across every domain now lives in one dedicated
+`eso-data-apps` domain**, instead of being bundled into each product's own
+domain — `dex-secret`, `grafana-secret`, `wireguard-secret`,
+`argo-workflows-secret`, `argocd-config-secret` (split out of
+`services/platform/argocd-config/config`, gitops repo, same "mixed chart
+split in two" treatment `bootstrap/README.md` documents for `dex`/`grafana`),
+and the two that used to live directly in `networking-apps`
+(`cert-manager-webhook-secret`/`external-dns-secret`). `eso_data_apps`
+`depends_on = [helm_release.secrets_apps]` — the ONE edge that fixes the
+finalizer race for every consumer at once: this release (and every
+`ExternalSecret` it owns) is guaranteed to finish destroying before
+`secrets-apps` — and therefore ESO's own controller — even starts tearing
+down. Every product domain that consumes one of these secrets just
+`depends_on = [helm_release.eso_data_apps]` instead of reasoning about ESO's
+own lifecycle directly.
+
+**The two ordering mechanisms are deliberately different, and shouldn't be
+conflated:**
+1. Raw `depends_on` between `helm_release` resources (used by `eso-data-apps`
+   → `secrets-apps`, and by every product domain → `eso-data-apps`) only
+   fixes *destroy* ordering — Helm apply itself is fast, so this doesn't
+   slow down startup, and ESO's own `refreshInterval` self-heals if a
+   consumer briefly starts before its secret exists (the same tolerance
+   every ESO consumer already accepted before this split).
+2. `kubernetes_job_v1` health-wait gates (the `wait_platform_apps_healthy`
+   pattern this repo already had, now factored into the
+   `modules/wait-argocd-apps-healthy` module — see that module's own
+   comment) are used only where a real hard, non-self-healing dependency
+   exists: CRD registration, an eager OIDC dial at pod startup, a live HTTP
+   API call. These genuinely delay creation of the dependent domain until
+   the upstream one reports `Synced` + `Healthy`.
+
+**The resulting DAG**, tier by tier:
+
+- **Tier 0** (parallel, unchanged): `secrets-apps`, `monitoring-apps`,
+  `backups-apps`. `eso-data-apps` sits right after `secrets-apps`
+  (`depends_on` only, not a health-wait — see mechanism 1 above).
+- **Tier 1** (`depends_on = [eso_data_apps]`; additionally
+  `depends_on = [module.wait_networking_healthy]` if the domain owns an
+  `HTTPRoute`, since every `HTTPRoute` is a Gateway API CRD type — the same
+  hard, non-self-healing "CRD not registered yet" sync-failure class as
+  `gateway-config`'s `ClusterIssuer`, documented below): `networking-apps`
+  (now also gains its own eso-data-apps dependency, even though it no
+  longer owns an ExternalSecret itself — kept for create-order tidiness,
+  not a correctness requirement anymore), `wireguard-apps` (no `HTTPRoute`,
+  so no networking wait), `dex-apps`, `argocd-config-apps`, `grafana-apps`.
+  `dex-apps` stayed its own domain rather than bundled with
+  `argocd-config-apps`/`grafana-apps` (which share its exact dependency
+  profile) specifically so Tier 2's wait-gate on "is Dex ready" isn't
+  diluted by unrelated apps' health. `grafana-apps` stayed out of
+  `monitoring-apps` for the mirror-image reason: folding it in would force
+  `kube-prometheus-stack`/`loki`/`tempo` (genuinely independent of
+  `networking-apps`) to also wait on networking's CRDs. `grafana`'s own
+  Velero-restore PreSync hook is deliberately left ungated against
+  `backups-apps` — confirmed self-contained/fail-open, same reasoning as
+  `gateway-config`'s identical Velero dependency (see that section above).
+- **Tier 2** (`depends_on = [module.wait_dex_healthy]`): `argo-workflows-apps`
+  — `argo-workflows/chart` eager-dials Dex's OIDC issuer at pod startup and
+  crash-loops if Dex isn't reachable, a real hard dependency unlike ESO's
+  self-heal tolerance. Its own `HTTPRoute`'s networking-apps dependency is
+  covered transitively via `dex-apps`' own wait-gate — no separate direct
+  edge needed.
+- **Tier 3** (`depends_on = [module.wait_argo_workflows_and_grafana_healthy]`):
+  `terraform-apply-apps` — its `grafana-managed` root's preflight calls
+  Grafana's live HTTP API directly, and its PostSync
+  `initial-run-workflow` hook needs `argo-workflows`' own
+  `WorkflowTemplate`/CRDs already installed.
+- **Final gate**: `module.wait_all_domains_healthy` (renamed from
+  `wait_platform_apps_healthy` — same resource in spirit, just checking
+  every domain now, not the original four) still gates `bootstrap`'s own
+  Application creation, same as before this follow-up — `bootstrap` now
+  only manages `demo`.
+
+`openbao-gateway` moved into `networking-apps` itself (not its own domain):
+it's a bare `HTTPRoute` with no `ExternalSecret` and no other dependency,
+and `networking-apps` already owns the Gateway API CRDs it needs — no
+reason to pay for a whole extra domain (release + wait-gate) for one
+HTTPRoute. `argocd-config-monitoring` (a `PrometheusRule`) moved into
+`monitoring-apps` itself for the identical reason — its only real
+dependency is that domain's own `kube-prometheus-stack-crds`, nothing
+`argocd-config`-related despite the name it inherited from its `chartPath`.

--- a/10-cluster/scaleway/platform-apps/values-argo-workflows.yaml
+++ b/10-cluster/scaleway/platform-apps/values-argo-workflows.yaml
@@ -1,0 +1,19 @@
+# Argo Workflows (controller + server) -- extracted from gitops repo's
+# bootstrap/values.yaml (infra#84 follow-up). argo-workflows-secret lives in
+# eso-data-apps now (argocd.tf's helm_release.eso_data_apps) -- this domain
+# just consumes the Secrets it materializes.
+#
+# argo-workflows/chart eager-dials Dex's OIDC issuer at pod startup
+# (server.sso.issuer, http://dex.gateway.svc:5556) and crash-loops if Dex
+# isn't reachable yet -- a real hard dependency, unlike ESO's
+# self-heals-via-refreshInterval tolerance. This domain therefore depends on
+# a health wait on dex-apps (argocd.tf's wait_dex_healthy gate), not just a
+# raw depends_on. argo-workflows-gateway's HTTPRoute transitively covers the
+# networking-apps CRD dependency too, via dex-apps' own
+# wait_networking_healthy gate -- no separate direct edge needed.
+apps:
+  # ── wave 0 ──────────────────────────────────────────────────────────────
+  - {name: argo-workflows, namespace: argo-workflows, chartPath: services/platform/argo-workflows/chart, valueFile: values-scaleway.yaml, wave: "0", syncWaveLabelPaths: ['argo-workflows.controller.podLabels.scalepack\.fr/sync-wave']}
+
+  # ── wave 1 ──────────────────────────────────────────────────────────────
+  - {name: argo-workflows-gateway, namespace: argo-workflows, chartPath: services/platform/argo-workflows/gateway, valueFile: values.yaml, wave: "1"}

--- a/10-cluster/scaleway/platform-apps/values-argocd-config.yaml
+++ b/10-cluster/scaleway/platform-apps/values-argocd-config.yaml
@@ -1,0 +1,15 @@
+# ArgoCD's own OIDC config + exposure -- extracted from gitops repo's
+# bootstrap/values.yaml (infra#84 follow-up). argocd-config-secret (the
+# ExternalSecret this used to bundle) lives in eso-data-apps now (argocd.tf's
+# helm_release.eso_data_apps) -- this domain's `argocd-config` just consumes
+# the Secret it materializes (via its PostSync restart-hook) and
+# argocd-config-gateway exposes argocd-server itself via HTTPRoute, same
+# hard dependency on networking-apps' Gateway API CRDs as every other
+# *-gateway domain -- see platform-apps/README.md's wait_networking_healthy
+# gate.
+apps:
+  # ── wave 0 ──────────────────────────────────────────────────────────────
+  - {name: argocd-config, namespace: argocd, chartPath: services/platform/argocd-config/config, valueFile: values.yaml, wave: "0"}
+
+  # ── wave 1 ──────────────────────────────────────────────────────────────
+  - {name: argocd-config-gateway, namespace: argocd, chartPath: services/platform/argocd-config/gateway, valueFile: values-scaleway.yaml, wave: "1"}

--- a/10-cluster/scaleway/platform-apps/values-dex.yaml
+++ b/10-cluster/scaleway/platform-apps/values-dex.yaml
@@ -1,0 +1,19 @@
+# Dex (shared OIDC provider) -- extracted from gitops repo's
+# bootstrap/values.yaml (infra#84 follow-up). dex-secret itself lives in
+# eso-data-apps now (argocd.tf's helm_release.eso_data_apps) -- this domain
+# just consumes the Secret it materializes. dex-gateway's HTTPRoute is a
+# Gateway API CRD type, same hard non-self-healing dependency class as
+# gateway-config's ClusterIssuer (see platform-apps/README.md) -- this
+# domain depends on a health wait on networking-apps (argocd.tf's
+# wait_networking_healthy gate), not just on eso-data-apps.
+#
+# Kept as its OWN domain rather than bundled with argocd-config/grafana
+# (which share the identical secrets-apps+networking-apps dependency
+# profile): argo-workflows-apps' own wait-gate needs to check specifically
+# "is Dex ready", not a bundle diluted by unrelated apps' health.
+apps:
+  # ── wave 0 ──────────────────────────────────────────────────────────────
+  - {name: dex, namespace: gateway, chartPath: services/platform/dex/chart, valueFile: values-scaleway.yaml, wave: "0", syncWaveLabelPaths: ['dex.podLabels.scalepack\.fr/sync-wave']}
+
+  # ── wave 1 ──────────────────────────────────────────────────────────────
+  - {name: dex-gateway, namespace: gateway, chartPath: services/platform/dex/gateway, valueFile: values.yaml, wave: "1"}

--- a/10-cluster/scaleway/platform-apps/values-eso-data.yaml
+++ b/10-cluster/scaleway/platform-apps/values-eso-data.yaml
@@ -1,0 +1,35 @@
+# Every ExternalSecret across every platform domain, centralized in ONE
+# place -- infra#84 follow-up, generalizing the fix for the ESO-controller-
+# finalizer-race bug (confirmed live 2026-08-25: cert-manager-webhook-secret/
+# external-dns-secret, then living directly in networking-apps, could get
+# their externalsecrets.external-secrets.io/externalsecret-cleanup finalizer
+# stranded on `terraform destroy` because networking-apps and secrets-apps
+# tore down in parallel with no ordering between them).
+#
+# Rather than fix that per-domain (each product domain individually
+# depends_on secrets-apps), every ExternalSecret-only chart lives here
+# instead, and THIS domain alone depends_on secrets-apps (argocd.tf's
+# helm_release.eso_data_apps) -- one edge protects every consumer at once,
+# and every consumer domain just depends_on THIS one instead of reasoning
+# about ESO's own lifecycle itself. See argocd.tf's helm_release.eso_data_apps
+# for the full "why", and platform-apps/README.md for the complete DAG.
+#
+# All one wave: none of these secrets depend on each other, only on
+# secrets-apps' ESO+OpenBao being reachable (self-heals via ESO's own
+# refreshInterval if it briefly isn't yet -- same tolerance every one of
+# these charts already accepted when it lived inside gitops repo's
+# `bootstrap`).
+apps:
+  # ── wave 0 ──────────────────────────────────────────────────────────────
+  - {name: dex-secret, namespace: gateway, chartPath: services/platform/dex/secret, valueFile: values.yaml, wave: "0"}
+  - {name: grafana-secret, namespace: monitoring, chartPath: services/platform/monitoring/grafana-secret, valueFile: values.yaml, wave: "0"}
+  - {name: wireguard-secret, namespace: wireguard, chartPath: services/platform/wireguard-site-to-site/secret, valueFile: values-scaleway.yaml, wave: "0"}
+  - {name: argo-workflows-secret, namespace: argo-workflows, chartPath: services/platform/argo-workflows/secret, valueFile: values.yaml, wave: "0"}
+  # argocd-config-secret: split out of services/platform/argocd-config/config
+  # (which used to bundle this ExternalSecret with the PostSync
+  # argocd-server restart hook) -- same "<product>/secret split out of a
+  # mixed chart" treatment gitops repo's bootstrap/README.md documents for
+  # dex/grafana back when they first needed it (wave 1's history).
+  - {name: argocd-config-secret, namespace: argocd, chartPath: services/platform/argocd-config/secret, valueFile: values.yaml, wave: "0"}
+  - {name: cert-manager-webhook-secret, namespace: cert-manager, chartPath: services/platform/cert-manager/webhook-secret, valueFile: values.yaml, wave: "0"}
+  - {name: external-dns-secret, namespace: external-dns, chartPath: services/platform/external-dns/secret, valueFile: values.yaml, wave: "0"}

--- a/10-cluster/scaleway/platform-apps/values-grafana.yaml
+++ b/10-cluster/scaleway/platform-apps/values-grafana.yaml
@@ -1,0 +1,22 @@
+# Grafana -- extracted from gitops repo's bootstrap/values.yaml (infra#84
+# follow-up). Kept out of monitoring-apps deliberately: folding it in would
+# force kube-prometheus-stack/loki/tempo/alloy/otel-collector (currently
+# genuinely independent of networking-apps) to also wait on networking's
+# Gateway API CRDs just because grafana-gateway needs them.
+#
+# grafana-secret lives in eso-data-apps now (argocd.tf's
+# helm_release.eso_data_apps) -- grafana just consumes the Secrets it
+# materializes. grafana-gateway's HTTPRoute needs networking-apps' Gateway
+# API CRDs (wait_networking_healthy gate, same as every other *-gateway
+# domain). grafana's own Velero-restore PreSync hook is deliberately left
+# ungated against backups-apps -- confirmed self-contained/fail-open
+# (queries the velero namespace's Backup/Restore objects directly and
+# proceeds with a fresh state if none shows up within its own budget), same
+# reasoning as gateway-config's identical Velero dependency -- see
+# platform-apps/README.md.
+apps:
+  # ── wave 0 ──────────────────────────────────────────────────────────────
+  - {name: grafana, namespace: monitoring, chartPath: services/platform/monitoring/grafana-chart, valueFile: values-scaleway.yaml, wave: "0"}
+
+  # ── wave 1 ──────────────────────────────────────────────────────────────
+  - {name: grafana-gateway, namespace: monitoring, chartPath: services/platform/monitoring/grafana-gateway, valueFile: values-scaleway.yaml, wave: "1"}

--- a/10-cluster/scaleway/platform-apps/values-monitoring.yaml
+++ b/10-cluster/scaleway/platform-apps/values-monitoring.yaml
@@ -32,6 +32,12 @@ apps:
   - {name: kube-prometheus-stack, namespace: monitoring, chartPath: services/platform/monitoring/chart, valueFile: values-scaleway.yaml, wave: "1", skipCrds: true, syncWaveLabelPaths: ['kube-prometheus-stack.prometheus.prometheusSpec.podMetadata.labels.scalepack\.fr/sync-wave', 'kube-prometheus-stack.prometheusOperator.podLabels.scalepack\.fr/sync-wave']}
   - {name: loki, namespace: monitoring, chartPath: services/platform/monitoring/loki-chart, valueFile: values-scaleway.yaml, wave: "1"}
   - {name: tempo, namespace: monitoring, chartPath: services/platform/monitoring/tempo-chart, valueFile: values-scaleway.yaml, wave: "1"}
+  # argocd-config-monitoring: a PrometheusRule, needs wave 0's
+  # kube-prometheus-stack-crds Established (the monitoring.coreos.dev CRDs)
+  # -- moved here from gitops repo's bootstrap (infra#84 follow-up) since
+  # its only real dependency is this domain's own CRDs, nothing
+  # argocd-config-related despite the name (inherited from its chartPath).
+  - {name: argocd-config-monitoring, namespace: argocd, chartPath: services/platform/argocd-config/monitoring, valueFile: values.yaml, wave: "1"}
 
   # ── wave 2 ──────────────────────────────────────────────────────────────
   # alloy / otel-collector: one wave after loki/tempo — both need the

--- a/10-cluster/scaleway/platform-apps/values-networking.yaml
+++ b/10-cluster/scaleway/platform-apps/values-networking.yaml
@@ -5,23 +5,24 @@
 # explicit choice). envoy-gateway, cert-manager (+ its Scaleway DNS01
 # webhook), external-dns, and gateway-config (the shared
 # GatewayClass/Gateway/ClusterIssuers every product's own *-gateway
-# HTTPRoute chart attaches to). Every product-specific *-gateway chart
-# (dex-gateway, grafana-gateway, argocd-config-gateway, openbao-gateway,
-# argo-workflows-gateway) stays in gitops repo's bootstrap — those are
-# per-product exposure, not shared routing infrastructure, and their own
-# prerequisite (this domain's Gateway) is now ready even earlier than
-# before.
+# HTTPRoute chart attaches to). openbao-gateway also lives here (added in
+# the infra#84 follow-up that finished migrating the rest of `bootstrap` —
+# it's a bare HTTPRoute with no other dependency, and this domain already
+# owns the Gateway API CRDs it needs). Every OTHER product-specific
+# *-gateway chart (dex-gateway, grafana-gateway, argocd-config-gateway,
+# argo-workflows-gateway) got its own dedicated domain instead (see
+# platform-apps/README.md's DAG) — each has a real hard dependency
+# (Dex/Grafana/etc. being Healthy) that would otherwise force this domain's
+# own, unrelated apps to wait on it.
 #
-# Unlike secrets-apps/monitoring-apps/backups-apps, this domain keeps using
-# OpenBao+ESO for its own secrets (cert-manager-webhook-secret,
-# external-dns-secret) rather than direct Terraform provisioning — these
-# aren't credentials Terraform itself originates (unlike thanos/loki/tempo/
-# velero's Object Storage keys), so there's nothing to gain by bypassing
-# ESO here. Moved together with their consumers (same reasoning as
-# secrets-apps' openbao+openbao-init) since bootstrap no longer runs after
-# this domain — a secret left behind in bootstrap's own wave 1 would apply
-# AFTER its consumer here already tried to start, inverting the ordering
-# these charts depend on.
+# cert-manager-webhook-secret/external-dns-secret used to live directly in
+# this domain — moved to eso-data-apps (argocd.tf's helm_release.eso_data_apps)
+# in the same follow-up, alongside every other domain's ExternalSecret, so
+# the ESO-controller-finalizer-race fix is one rule applied uniformly
+# instead of a per-domain special case. envoy-gateway/cert-manager/
+# external-dns still consume those Secrets at runtime from wherever they
+# live now — unaffected, same "brief race, self-heals" tolerance every
+# other ESO consumer here already accepts.
 #
 # gateway-config's PreSync hook restores its TLS Secret from a Velero
 # backup (services/platform/gateway/config/README.md) — deliberately NOT
@@ -34,25 +35,16 @@
 # Terraform-level wait needed between this domain and backups-apps.
 apps:
   # ── wave 0 ──────────────────────────────────────────────────────────────
-  # cert-manager-webhook-secret / external-dns-secret: still ESO
-  # ExternalSecrets (see header comment above) — self-heal if OpenBao/ESO
-  # (secrets-apps domain) isn't quite ready yet at this domain's own start,
-  # same "brief race, self-heals" tolerance every other *-secret chart in
-  # gitops repo's bootstrap already accepts.
-  - {name: cert-manager-webhook-secret, namespace: cert-manager, chartPath: services/platform/cert-manager/webhook-secret, valueFile: values.yaml, wave: "0"}
-  - {name: external-dns-secret, namespace: external-dns, chartPath: services/platform/external-dns/secret, valueFile: values.yaml, wave: "0"}
-
-  # ── wave 1 ──────────────────────────────────────────────────────────────
   # envoy-gateway + cert-manager (+ its Scaleway DNS01 ACME webhook): don't
   # depend on each other — what actually needs both is gateway-config
-  # (wave 2): envoy-gateway for the Gateway API CRDs, cert-manager for the
+  # (wave 1): envoy-gateway for the Gateway API CRDs, cert-manager for the
   # cert-manager.io CRDs its ClusterIssuers need.
-  - {name: envoy-gateway, namespace: envoy-gateway-system, chartPath: services/platform/gateway/chart, valueFile: values-scaleway.yaml, wave: "1", syncWaveLabelPaths: ['gateway-helm.deployment.pod.labels.scalepack\.fr/sync-wave']}
-  - {name: cert-manager, namespace: cert-manager, chartPath: services/platform/cert-manager/chart, valueFile: values-scaleway.yaml, wave: "1", syncWaveLabelPaths: ['cert-manager.podLabels.scalepack\.fr/sync-wave', 'cert-manager.webhook.podLabels.scalepack\.fr/sync-wave', 'cert-manager.cainjector.podLabels.scalepack\.fr/sync-wave']}
-  - {name: cert-manager-webhook-scaleway, namespace: cert-manager, chartPath: services/platform/cert-manager/webhook-chart, valueFile: values-scaleway.yaml, wave: "1", syncWaveLabelPaths: ['scaleway-certmanager-webhook.podLabels.scalepack\.fr/sync-wave']}
+  - {name: envoy-gateway, namespace: envoy-gateway-system, chartPath: services/platform/gateway/chart, valueFile: values-scaleway.yaml, wave: "0", syncWaveLabelPaths: ['gateway-helm.deployment.pod.labels.scalepack\.fr/sync-wave']}
+  - {name: cert-manager, namespace: cert-manager, chartPath: services/platform/cert-manager/chart, valueFile: values-scaleway.yaml, wave: "0", syncWaveLabelPaths: ['cert-manager.podLabels.scalepack\.fr/sync-wave', 'cert-manager.webhook.podLabels.scalepack\.fr/sync-wave', 'cert-manager.cainjector.podLabels.scalepack\.fr/sync-wave']}
+  - {name: cert-manager-webhook-scaleway, namespace: cert-manager, chartPath: services/platform/cert-manager/webhook-chart, valueFile: values-scaleway.yaml, wave: "0", syncWaveLabelPaths: ['scaleway-certmanager-webhook.podLabels.scalepack\.fr/sync-wave']}
 
-  # ── wave 2 ──────────────────────────────────────────────────────────────
-  # gateway-config needs BOTH wave 1's envoy-gateway (Gateway API CRDs) AND
+  # ── wave 1 ──────────────────────────────────────────────────────────────
+  # gateway-config needs BOTH wave 0's envoy-gateway (Gateway API CRDs) AND
   # cert-manager (cert-manager.io CRDs) to have actually finished
   # installing, not just exist — a genuinely hard dependency (its
   # ClusterIssuer objects are cert-manager.io-typed; ArgoCD's sync fails
@@ -61,5 +53,13 @@ apps:
   # consistent DNS reconciliation, no observed race) but shares this wave
   # rather than getting its own — same "rides along, wave reuse is free"
   # reasoning gitops repo's bootstrap/README.md uses throughout.
-  - {name: gateway-config, namespace: gateway, chartPath: services/platform/gateway/config, valueFile: values-scaleway.yaml, wave: "2"}
-  - {name: external-dns, namespace: external-dns, chartPath: services/platform/external-dns/chart, valueFile: values-scaleway.yaml, wave: "2", syncWaveLabelPaths: ['external-dns.podLabels.scalepack\.fr/sync-wave']}
+  - {name: gateway-config, namespace: gateway, chartPath: services/platform/gateway/config, valueFile: values-scaleway.yaml, wave: "1"}
+  - {name: external-dns, namespace: external-dns, chartPath: services/platform/external-dns/chart, valueFile: values-scaleway.yaml, wave: "1", syncWaveLabelPaths: ['external-dns.podLabels.scalepack\.fr/sync-wave']}
+
+  # ── wave 2 ──────────────────────────────────────────────────────────────
+  # openbao-gateway: bare HTTPRoute onto openbao's Service (secrets-apps
+  # domain) — same "rides along, no dependency between siblings" reasoning
+  # as external-dns above, one wave later purely so it doesn't share a wave
+  # with gateway-config's own hard CRD dependency (not required to be this
+  # late, just avoids growing wave 1's already-load-bearing comment).
+  - {name: openbao-gateway, namespace: openbao, chartPath: services/platform/openbao/gateway, valueFile: values-scaleway.yaml, wave: "2"}

--- a/10-cluster/scaleway/platform-apps/values-terraform-apply.yaml
+++ b/10-cluster/scaleway/platform-apps/values-terraform-apply.yaml
@@ -1,0 +1,16 @@
+# terraform-apply (the CronWorkflows that run this repo's own `terraform
+# apply` against grafana-bootstrap/grafana-managed and friends) --
+# extracted from gitops repo's bootstrap/values.yaml (infra#84 follow-up).
+# Its own PostSync hook (initial-run-workflow) submits grafana-bootstrap
+# then grafana-managed immediately on sync, and grafana-managed's preflight
+# calls Grafana's live HTTP API directly -- a hard, non-self-healing
+# dependency on grafana being actually Healthy (not just Synced), same
+# class as argo-workflows' eager Dex dial. It also reads
+# argo-workflows-scaleway-state-credentials + per-root extraSecretName
+# Secrets from eso-data-apps (via argo-workflows-secret) and needs the
+# argo-workflows/chart's CRDs + WorkflowTemplate already installed. This
+# domain therefore depends on a health wait on BOTH argo-workflows-apps AND
+# grafana-apps (argocd.tf's wait_argo_workflows_and_grafana_healthy gate).
+apps:
+  # ── wave 0 ──────────────────────────────────────────────────────────────
+  - {name: terraform-apply, namespace: argo-workflows, chartPath: services/platform/argo-workflows/terraform-apply, valueFile: values-scaleway.yaml, wave: "0"}

--- a/10-cluster/scaleway/platform-apps/values-wireguard.yaml
+++ b/10-cluster/scaleway/platform-apps/values-wireguard.yaml
@@ -1,0 +1,12 @@
+# WireGuard site-to-site tunnel -- extracted from gitops repo's
+# bootstrap/values.yaml (infra#84 follow-up: finishing the platform-apps
+# extraction so only `demo` remains in bootstrap). wireguard-secret itself
+# lives in eso-data-apps now (every ExternalSecret across every domain does
+# -- see argocd.tf's helm_release.eso_data_apps for why); this domain just
+# consumes the Secret it materializes. No HTTPRoute here either (no Gateway
+# API dependency), so this domain only needs eso-data-apps
+# (argocd.tf's helm_release.wireguard_apps depends_on
+# helm_release.eso_data_apps), not a health wait on networking-apps.
+apps:
+  # ── wave 0 ──────────────────────────────────────────────────────────────
+  - {name: wireguard-config, namespace: wireguard, chartPath: services/platform/wireguard-site-to-site/config, valueFile: values-scaleway.yaml, wave: "0", syncWaveLabelPaths: ['syncWave']}


### PR DESCRIPTION
## Summary
- Migrates every remaining `gitops` `bootstrap` app (dex, wireguard, grafana, argo-workflows, argocd-config, terraform-apply, and their `*-gateway` HTTPRoutes) into this repo's own Terraform-managed `platform-apps` domains — only `demo` is left in `gitops`'s `bootstrap`.
- Generalizes the fix for the ESO `ExternalSecret` cross-domain finalizer race (`networking-apps`' `cert-manager-webhook-secret`/`external-dns-secret` could get stranded on `terraform destroy`): every domain is now its own `helm_release`, and every `ExternalSecret` across every domain now lives in one dedicated `eso-data-apps` domain that alone `depends_on` `secrets-apps`.
- Factors the kubectl-poll-until-healthy pattern into a reusable `modules/wait-argocd-apps-healthy` module.

See `10-cluster/scaleway/platform-apps/README.md`'s new "Finishing the migration + generalizing the finalizer-race fix" section for the full DAG/design rationale.

Companion gitops PR: https://github.com/IntegratedDynamic/gitops/pull/49

## Test plan
- [x] `terraform validate` / `terraform fmt -check` clean
- [x] `terraform plan` against the live workspace resolves cleanly
- [x] Live `terraform apply` against the real Kapsule cluster — all 48 Applications reached Synced+Healthy, including `bootstrap`/`demo`, in the right DAG order (dex-apps → argo-workflows-apps; dex/argocd-config/grafana-apps → networking-apps' health gate; argo-workflows+grafana → terraform-apply-apps)
- [x] Live `terraform destroy` — confirmed the actual fix: `eso-data-apps` (holding every `ExternalSecret`, including `cert-manager-webhook-secret`/`external-dns-secret`) destroyed cleanly in 24s while ESO (`secrets-apps`) was still alive, all finalizers processed with **no manual `kubectl patch`** needed. Full destroy verified end-to-end, state ends empty.

### Unrelated findings from live testing (not caused by this PR, noted for future reference)
- Interrupting a `terraform apply`/`destroy` mid-Helm-operation (Ctrl+C) can leave a Helm release's own record permanently stuck at `STATUS: uninstalling` (independent of the underlying Kubernetes objects, which are already gone) — blocks any future create of an Application with that name. Fix: `kubectl delete secret sh.helm.release.v1.<release>.v<rev> -n argocd`.
- A `helm_release` resource can occasionally deadlock inside the Terraform Helm provider itself when many `helm_release` resources apply concurrently in one run (observed: zero CPU, zero open network connections, no cluster-side blocker — a provider-level concurrency issue). Re-running `apply` after the stuck release record is cleaned up resolves it (subsequent creates complete in ~2s).
- Scaleway's own cluster teardown (`scaleway_k8s_cluster`/`scaleway_k8s_pool` with `delete_additional_resources = true`) has real eventual-consistency races on `destroy` — e.g. the security group delete can fail with "linked to servers" right after the pool reports destroyed, or the cluster's own delete waiter can error `unexpected state 'Active', wanted target ''` while nodes are still asynchronously stopping. Both self-resolve on a plain retry.

Closes #84

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
