### PR TITLE
fix: terraform-apply's gitRef follows infra_revision, with fallback to main

### DIFF
--- a/10-cluster/scaleway/argocd.tf
+++ b/10-cluster/scaleway/argocd.tf
@@ -23,6 +23,65 @@ locals {
   # at once.
   argocd_controller_memory_limit_mib = 1500
   argocd_controller_gomemlimit_mib   = floor(local.argocd_controller_memory_limit_mib * 0.85)
+
+  # Both ArgoCD Applications' own `targetRevision` (evaluated by ArgoCD's
+  # repo-server) and the plain `git clone --branch` step inside
+  # terraform-apply's WorkflowTemplate (infra#76's gitRef) assume the
+  # branch named by var.gitops_revision/var.infra_revision actually exists
+  # on its repo -- true for the "override on your own branch, test
+  # end-to-end, never merge that change" DevX trick IF you remember to
+  # reset it before merging, but ArgoCD has NO built-in fallback: an
+  # unresolvable targetRevision just sits in ComparisonError forever, no
+  # automatic revert to a previous/default revision. Resolved here instead,
+  # at apply time (before ArgoCD ever sees a revision) -- see the
+  # data.external "*_revision_exists" pair + effective_*_revision locals
+  # below.
+  gitops_source_repo = "https://github.com/IntegratedDynamic/gitops.git"
+}
+
+# `--heads`-only existence probe per repo/revision -- always exits 0 and
+# reports {"exists": "true"|"false"} in its own JSON, never a hard
+# data-source failure on a missing branch (unlike e.g. `data "http"` against
+# GitHub's API, which errors the whole apply on a 404). Only run when the
+# var isn't already "main" (count) -- the common case makes zero network
+# calls; effective_*_revision below treats a skipped check as "exists" so
+# the result still resolves to "main" either way when count = 0.
+data "external" "gitops_revision_exists" {
+  count = var.gitops_revision != "main" ? 1 : 0
+
+  program = ["sh", "-c", <<-EOT
+    if git ls-remote --exit-code --heads ${local.gitops_source_repo} "${var.gitops_revision}" >/dev/null 2>&1; then
+      echo '{"exists": "true"}'
+    else
+      echo '{"exists": "false"}'
+    fi
+  EOT
+  ]
+}
+
+data "external" "infra_revision_exists" {
+  count = var.infra_revision != "main" ? 1 : 0
+
+  program = ["sh", "-c", <<-EOT
+    if git ls-remote --exit-code --heads ${local.platform_apps_source_repo} "${var.infra_revision}" >/dev/null 2>&1; then
+      echo '{"exists": "true"}'
+    else
+      echo '{"exists": "false"}'
+    fi
+  EOT
+  ]
+}
+
+locals {
+  # The revision every targetRevision/gitRef below actually uses -- var.
+  # gitops_revision/var.infra_revision verbatim when that branch exists
+  # upstream (or when it's already "main", never probed), "main" otherwise.
+  # `--heads` only checks branches, matching these vars' documented
+  # "override on your own branch" purpose -- a tag or bare commit SHA would
+  # (incorrectly) fall back to "main" too, but neither is a supported value
+  # for either variable today.
+  effective_gitops_revision = try(data.external.gitops_revision_exists[0].result.exists, "true") == "true" ? var.gitops_revision : "main"
+  effective_infra_revision  = try(data.external.infra_revision_exists[0].result.exists, "true") == "true" ? var.infra_revision : "main"
 }
 
 resource "helm_release" "argocd" {
@@ -376,14 +435,14 @@ applications:
 
     source:
       repoURL: https://github.com/IntegratedDynamic/gitops.git
-      targetRevision: ${var.gitops_revision}
+      targetRevision: ${local.effective_gitops_revision}
       path: bootstrap
       helm:
         parameters:
           - name: env
             value: scaleway
           - name: revision
-            value: ${var.gitops_revision}
+            value: ${local.effective_gitops_revision}
 
     destination:
       server: https://kubernetes.default.svc
@@ -470,14 +529,14 @@ applications:
     project: default
     source:
       repoURL: ${local.platform_apps_source_repo}
-      targetRevision: ${var.infra_revision}
+      targetRevision: ${local.effective_infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
         valueFiles:
           - values-secrets.yaml
         parameters:
           - name: revision
-            value: ${var.gitops_revision}
+            value: ${local.effective_gitops_revision}
     destination:
       server: https://kubernetes.default.svc
       namespace: argocd
@@ -540,14 +599,14 @@ applications:
     project: default
     source:
       repoURL: ${local.platform_apps_source_repo}
-      targetRevision: ${var.infra_revision}
+      targetRevision: ${local.effective_infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
         valueFiles:
           - values-eso-data.yaml
         parameters:
           - name: revision
-            value: ${var.gitops_revision}
+            value: ${local.effective_gitops_revision}
     destination:
       server: https://kubernetes.default.svc
       namespace: argocd
@@ -596,14 +655,14 @@ applications:
     project: default
     source:
       repoURL: ${local.platform_apps_source_repo}
-      targetRevision: ${var.infra_revision}
+      targetRevision: ${local.effective_infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
         valueFiles:
           - values-monitoring.yaml
         parameters:
           - name: revision
-            value: ${var.gitops_revision}
+            value: ${local.effective_gitops_revision}
     destination:
       server: https://kubernetes.default.svc
       namespace: argocd
@@ -656,14 +715,14 @@ applications:
     project: default
     source:
       repoURL: ${local.platform_apps_source_repo}
-      targetRevision: ${var.infra_revision}
+      targetRevision: ${local.effective_infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
         valueFiles:
           - values-backups.yaml
         parameters:
           - name: revision
-            value: ${var.gitops_revision}
+            value: ${local.effective_gitops_revision}
     destination:
       server: https://kubernetes.default.svc
       namespace: argocd
@@ -715,14 +774,14 @@ applications:
     project: default
     source:
       repoURL: ${local.platform_apps_source_repo}
-      targetRevision: ${var.infra_revision}
+      targetRevision: ${local.effective_infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
         valueFiles:
           - values-networking.yaml
         parameters:
           - name: revision
-            value: ${var.gitops_revision}
+            value: ${local.effective_gitops_revision}
     destination:
       server: https://kubernetes.default.svc
       namespace: argocd
@@ -767,14 +826,14 @@ applications:
     project: default
     source:
       repoURL: ${local.platform_apps_source_repo}
-      targetRevision: ${var.infra_revision}
+      targetRevision: ${local.effective_infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
         valueFiles:
           - values-wireguard.yaml
         parameters:
           - name: revision
-            value: ${var.gitops_revision}
+            value: ${local.effective_gitops_revision}
     destination:
       server: https://kubernetes.default.svc
       namespace: argocd
@@ -901,14 +960,14 @@ applications:
     project: default
     source:
       repoURL: ${local.platform_apps_source_repo}
-      targetRevision: ${var.infra_revision}
+      targetRevision: ${local.effective_infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
         valueFiles:
           - values-dex.yaml
         parameters:
           - name: revision
-            value: ${var.gitops_revision}
+            value: ${local.effective_gitops_revision}
     destination:
       server: https://kubernetes.default.svc
       namespace: argocd
@@ -949,14 +1008,14 @@ applications:
     project: default
     source:
       repoURL: ${local.platform_apps_source_repo}
-      targetRevision: ${var.infra_revision}
+      targetRevision: ${local.effective_infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
         valueFiles:
           - values-argocd-config.yaml
         parameters:
           - name: revision
-            value: ${var.gitops_revision}
+            value: ${local.effective_gitops_revision}
     destination:
       server: https://kubernetes.default.svc
       namespace: argocd
@@ -997,14 +1056,14 @@ applications:
     project: default
     source:
       repoURL: ${local.platform_apps_source_repo}
-      targetRevision: ${var.infra_revision}
+      targetRevision: ${local.effective_infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
         valueFiles:
           - values-grafana.yaml
         parameters:
           - name: revision
-            value: ${var.gitops_revision}
+            value: ${local.effective_gitops_revision}
     destination:
       server: https://kubernetes.default.svc
       namespace: argocd
@@ -1066,14 +1125,14 @@ applications:
     project: default
     source:
       repoURL: ${local.platform_apps_source_repo}
-      targetRevision: ${var.infra_revision}
+      targetRevision: ${local.effective_infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
         valueFiles:
           - values-argo-workflows.yaml
         parameters:
           - name: revision
-            value: ${var.gitops_revision}
+            value: ${local.effective_gitops_revision}
     destination:
       server: https://kubernetes.default.svc
       namespace: argocd
@@ -1139,14 +1198,19 @@ applications:
     project: default
     source:
       repoURL: ${local.platform_apps_source_repo}
-      targetRevision: ${var.infra_revision}
+      targetRevision: ${local.effective_infra_revision}
       path: 10-cluster/scaleway/platform-apps
       helm:
         valueFiles:
           - values-terraform-apply.yaml
         parameters:
           - name: revision
-            value: ${var.gitops_revision}
+            value: ${local.effective_gitops_revision}
+          # infra#76: threads THIS repo's own revision through so the
+          # terraform-apply app's gitRefParam (values-terraform-apply.yaml)
+          # can override its chart's hardcoded `gitRef: main` default.
+          - name: infraRevision
+            value: ${local.effective_infra_revision}
     destination:
       server: https://kubernetes.default.svc
       namespace: argocd

--- a/10-cluster/scaleway/platform-apps/templates/apps.yaml
+++ b/10-cluster/scaleway/platform-apps/templates/apps.yaml
@@ -47,16 +47,26 @@ spec:
       # skipCrds/dedicated-CRDs-Application split for kube-prometheus-stack.
       skipCrds: true
       {{- end }}
-      {{- if .syncWaveLabelPaths }}
-      # Same anti-affinity wave-label injection as
-      # gitops repo's bootstrap/templates/scaleway.yaml — see that file's
-      # comment for the full "why" (forceString avoids a bare digit
-      # rendering as an unquoted YAML integer label value).
+      {{- if or .syncWaveLabelPaths .gitRefParam }}
       parameters:
+        {{- if .syncWaveLabelPaths }}
+        # Same anti-affinity wave-label injection as
+        # gitops repo's bootstrap/templates/scaleway.yaml — see that file's
+        # comment for the full "why" (forceString avoids a bare digit
+        # rendering as an unquoted YAML integer label value).
         {{- range .syncWaveLabelPaths }}
         - name: {{ . }}
           value: {{ $app.wave | quote }}
           forceString: true
+        {{- end }}
+        {{- end }}
+        {{- if .gitRefParam }}
+        # infra#76: overrides this app's chart's own `gitRef` default (a
+        # static "main" in its values file) with THIS repo's own revision,
+        # so a paired infra/gitops feature-branch test actually reads the
+        # infra branch under test instead of always reading infra's main.
+        - name: gitRef
+          value: {{ $.Values.infraRevision | quote }}
         {{- end }}
       {{- end }}
 

--- a/10-cluster/scaleway/platform-apps/values-terraform-apply.yaml
+++ b/10-cluster/scaleway/platform-apps/values-terraform-apply.yaml
@@ -13,4 +13,8 @@
 # grafana-apps (argocd.tf's wait_argo_workflows_and_grafana_healthy gate).
 apps:
   # ── wave 0 ──────────────────────────────────────────────────────────────
-  - {name: terraform-apply, namespace: argo-workflows, chartPath: services/platform/argo-workflows/terraform-apply, valueFile: values-scaleway.yaml, wave: "0"}
+  # gitRefParam: true (infra#76) -- overrides this chart's own hardcoded
+  # `gitRef: main` (values-scaleway.yaml) with var.infra_revision, so the
+  # in-cluster CronWorkflows git-clone the infra branch actually under
+  # test instead of always infra's main.
+  - {name: terraform-apply, namespace: argo-workflows, chartPath: services/platform/argo-workflows/terraform-apply, valueFile: values-scaleway.yaml, wave: "0", gitRefParam: true}

--- a/10-cluster/scaleway/platform-apps/values.yaml
+++ b/10-cluster/scaleway/platform-apps/values.yaml
@@ -6,12 +6,21 @@
 repoURL: https://github.com/IntegratedDynamic/gitops.git
 revision: main
 
+# THIS repo's (infrastructure) own revision, i.e. var.infra_revision --
+# distinct from `revision` above (that one's the gitops repo's ref).
+# Consumed by apps whose `gitRefParam: true` (see templates/apps.yaml) --
+# today just terraform-apply, which needs it to override its chart's own
+# `gitRef` value (infra#76: was hardcoded to "main" independent of
+# infra_revision, so a paired infra/gitops feature branch pair silently
+# read infra's main instead of the branch under test).
+infraRevision: main
+
 # Populated per-domain by values-secrets.yaml / values-monitoring.yaml /
-# values-backups.yaml. Each entry: {name, namespace, chartPath, valueFile,
-# wave, skipCrds?, syncWaveLabelPaths?} — same shape as gitops repo's
-# bootstrap/values.yaml scalewayApps list (this chart's templates/apps.yaml
-# renders it the same way). wave here is domain-local (parallel across
-# secrets/monitoring/backups, ordered only within one domain) — NOT the
-# same numbering the gitops repo's bootstrap chart uses for its own
-# remaining apps.
+# values-backups.yaml / values-terraform-apply.yaml. Each entry: {name,
+# namespace, chartPath, valueFile, wave, skipCrds?, syncWaveLabelPaths?,
+# gitRefParam?} — same shape as gitops repo's bootstrap/values.yaml
+# scalewayApps list (this chart's templates/apps.yaml renders it the same
+# way). wave here is domain-local (parallel across secrets/monitoring/
+# backups, ordered only within one domain) — NOT the same numbering the
+# gitops repo's bootstrap chart uses for its own remaining apps.
 apps: []

--- a/10-cluster/scaleway/variables.tf
+++ b/10-cluster/scaleway/variables.tf
@@ -34,6 +34,13 @@ variable "cluster_name" {
   default     = "scaleway-homelab"
 }
 
+# Branch of the gitops repo ArgoCD's `bootstrap` (and every platform
+# domain's own child Applications) pull from. "Override on your own branch,
+# test end-to-end, never merge that change" DevX trick -- if the named
+# branch doesn't actually exist on gitops (never pushed, or merged and
+# deleted since), argocd.tf's effective_gitops_revision local falls back to
+# "main" itself at apply time, since ArgoCD has no such fallback of its
+# own (an unresolvable targetRevision just sits in ComparisonError).
 variable "gitops_revision" {
   type    = string
   default = "main"
@@ -43,7 +50,8 @@ variable "gitops_revision" {
 # backups-apps Applications pull platform-apps/ from — see argocd.tf's
 # argocd_platform_apps helm_release. Same "override on your own branch to
 # test end-to-end, never merge that change" DevX trick as gitops_revision
-# above; MUST stay "main" on origin/main.
+# above (same apply-time fallback-to-main too, see argocd.tf's
+# effective_infra_revision); MUST stay "main" on origin/main.
 variable "infra_revision" {
   type    = string
   default = "main"


### PR DESCRIPTION
## Summary
- `terraform-apply`'s in-cluster CronWorkflows git-clone this repo to run `terraform apply` against `11-secrets/openbao/*` / `12-monitoring/grafana/*` — via a `gitRef: main` literal in the gitops chart's own values file (`services/platform/argo-workflows/terraform-apply/values-scaleway.yaml`), completely independent of `var.infra_revision`, which already drives every other `platform-apps` Application's `targetRevision`.
- Adds a generic `gitRefParam: true` app flag in `platform-apps/templates/apps.yaml` that injects a `gitRef` Helm parameter, sourced from a new chart-level `infraRevision` value threaded from `var.infra_revision` via the existing `terraform_apply_apps` helm_release in `argocd.tf`.
- No `gitops` repo change needed — the chart's `gitRef: main` stays as the default, now just overridable via the ArgoCD Application's own Helm parameters (same mechanism `revision` already uses).

**Follow-up added after review feedback:** ArgoCD has no built-in fallback when a `targetRevision` doesn't resolve (a branch that was never pushed, or merged and deleted) — the Application just sits in `ComparisonError` forever. That's a real risk for the "override `gitops_revision`/`infra_revision` on your own branch to test end-to-end" DevX trick, e.g. an infra-only change with no matching gitops branch. Since this is all applied via Terraform anyway, the fallback is resolved *before* ArgoCD ever sees a revision:
- `data.external.{gitops,infra}_revision_exists` probes each branch's actual existence via `git ls-remote --heads` (always exits 0, reports `{"exists": "true"|"false"}` in its own JSON — never a hard data-source failure on a missing branch, unlike e.g. `data "http"` against GitHub's API erroring on a 404). Skipped entirely when the var is already `"main"` (the common case), so zero extra network calls in steady state.
- `local.effective_gitops_revision` / `local.effective_infra_revision` resolve to the requested branch when it exists, `"main"` otherwise — every `targetRevision`/`gitRef` in `argocd.tf` (12 Applications, plus the new `gitRef` parameter from this PR) now reads from these instead of the raw vars.

Closes #76.

## Test plan
- [x] `terraform fmt -check -diff` clean on the touched `.tf` files
- [x] `terraform validate` passes (confirms no dependency cycle between the probes and the effective-revision locals)
- [x] `helm template` on `platform-apps` with `values-terraform-apply.yaml` confirms the rendered child Application carries `helm.parameters: [{name: gitRef, value: <infraRevision>}]`
- [x] `helm template` on `platform-apps` with `values-secrets.yaml`/`values-monitoring.yaml` (apps without `gitRefParam`) confirms no regression — `syncWaveLabelPaths`-only apps still render their `parameters:` block unchanged
- [x] Manually ran the probe script's `git ls-remote --heads` logic against both repos: an existing branch (`main`) resolves `true`, this PR's branch (which exists on `infrastructure` but not `gitops`) resolves `false` — confirming the fallback path actually triggers for the "infra-only change" scenario this is meant to catch
- [ ] Live test: apply with `infra_revision` set to a branch that doesn't exist on `infrastructure` (or `gitops_revision` set to a branch that doesn't exist on `gitops`), confirm every Application still resolves to `main` instead of `ComparisonError`