### PR TITLE
chore: start the Scaleway node pool at 1 node instead of 4

### DIFF
--- a/10-cluster/scaleway/env/10-cluster-scaleway-dev.tfvars
+++ b/10-cluster/scaleway/env/10-cluster-scaleway-dev.tfvars
@@ -1,5 +1,5 @@
 cluster_name = "scaleway-homelab"
-node_count   = 4
+node_count   = 1
 
 # Cross-root state reads — see 00-foundation/scaleway/env/00-foundation-scaleway-dev.tfvars
 # for the full bucket list. Keys updated 2026-08-24 (workspace-naming


### PR DESCRIPTION
## Summary
- `10-cluster/scaleway/env/10-cluster-scaleway-dev.tfvars`: `node_count` 4 → 1.
- Autoscaling is already on (`min_size = 1`, `max_size = 5`, `autoscaling = true`) — the pool can grow on its own as real pressure shows up, no need to pay for 4 nodes at boot.

## Note
`main.tf`'s own comment on `scaleway_k8s_pool.default` warns that too few nodes at startup can cause node-pressure-eviction race conditions during ArgoCD's initial full-tree sync (the DEV1-M → DEV1-L bump and GOMEMLIMIT tuning elsewhere in this file were reactions to exactly that class of issue). Worth a real from-scratch `apply` to confirm 1 node autoscales fast enough under the initial burst before relying on this for good — flagging, not blocking, since requested explicitly.

## Test plan
- [ ] Live test: `hard-destroy` + `apply` from scratch, confirm the pool scales past 1 node before anything hits sustained node pressure, and the full ArgoCD tree still reaches Healthy.