### PR TITLE
fix(10-cluster/scaleway): run homelab on Let's Encrypt staging as standing state

### DIFF
--- a/10-cluster/scaleway/env/10-cluster-scaleway-dev.tfvars
+++ b/10-cluster/scaleway/env/10-cluster-scaleway-dev.tfvars
@@ -1,6 +1,26 @@
 cluster_name = "scaleway-homelab"
 node_count   = 2
 
+# This homelab runs on Let's Encrypt STAGING, not prod, as its standing
+# state (see var.letsencrypt_staging). Two reasons, both confirmed live:
+#  1. gateway/cert-restore restores the scalepack.fr wildcard TLS Secret
+#     from the latest Velero backup on every fresh boot -- and every
+#     backup taken so far is from a staging-issued cert. cert-manager
+#     treats the restored Secret as satisfying the Certificate (right
+#     SANs, valid dates) and does NOT re-issue against letsencrypt-prod,
+#     so envoy-gateway ends up serving a staging cert regardless of which
+#     ClusterIssuer is "active". Running the whole platform on staging
+#     keeps ArgoCD/OpenBao's server-side OIDC calls to auth.scalepack.fr
+#     trusting the right root (their rootCA / oidc_discovery_ca_pem
+#     overrides only kick in when this flag is true) instead of failing
+#     "x509: certificate signed by unknown authority".
+#  2. This cluster is rebuilt from scratch often enough that LE's prod
+#     rate limit (5 duplicate certs/week) is a real risk; staging's
+#     limits are far higher.
+# Flip to false only alongside a deliberate move to prod certs (fresh
+# prod-issued backup, or cert-restore disabled).
+letsencrypt_staging = true
+
 # Cross-root state reads — see 00-foundation/scaleway/env/00-foundation-scaleway-dev.tfvars
 # for the full bucket list. Keys updated 2026-08-24 (workspace-naming
 # refacto) to point at each target root's new prefix/workspace.


### PR DESCRIPTION
## Context

The 2026-08-29 apply on `main` (post wait-graph merge) left ArgoCD and OpenBao **OIDC login broken** — Argo Workflows and Grafana were fine.

## Root cause (confirmed live)

`gateway/cert-restore` (backups-apps wave 1) restores `gateway/scalepack-fr-wildcard-tls` from the latest Velero backup on every fresh boot. Every backup so far holds a **Let's Encrypt staging** wildcard cert (`i:CN=YR1` → `Root YR`, from the staging test period). cert-manager treats the restored Secret as satisfying the `Certificate` (correct SANs, valid dates) and does **not** re-issue against `letsencrypt-prod`, so envoy-gateway serves the staging cert.

With `letsencrypt_staging=false`, ArgoCD and OpenBao do server-side OIDC calls to `https://auth.scalepack.fr` with Go's strict TLS → `x509: certificate signed by unknown authority`. Argo Workflows / Grafana reach Dex over in-cluster HTTP (`http://dex.gateway.svc:5556`), so they're unaffected.

```
auth.scalepack.fr:  CN=*.scalepack.fr → i:CN=YR1 → i:CN=Root YR → i:CN=ISRG Root X1   (LE staging chain)
openbao log:  Get "https://auth.scalepack.fr/.well-known/openid-configuration": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

## Change

`letsencrypt_staging = true` in `10-cluster-scaleway-dev.tfvars` as the **standing** state (not a live-test override):

- ArgoCD `oidc.config.rootCA` + OpenBao `oidc_discovery_ca_pem` trust the LE staging root → OIDC login works.
- `gateway-config` uses the `letsencrypt-staging` ClusterIssuer → consistent with what `cert-restore` actually restores.
- Safer against LE **prod**'s 5-duplicate-certs/week limit given how often this cluster is rebuilt.

Flip back to `false` only alongside a deliberate move to prod certs (fresh prod-issued backup, or `cert-restore` disabled).

## Test

Merge → `workflow_dispatch` apply on `main` → verify ArgoCD + OpenBao OIDC login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)